### PR TITLE
Ansible modules for PowerStore release version 1.7.0

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,10 @@
 # ansible-powerstore Change Log
+## Version 1.7.0 - released on 27/09/2022
+- Added support for cluster creation and validating cluster creation attributes.
+- Added support to associate/disassociate protection policy to/from a NAS server.
+- Added support to handle filesystem and NAS server replication sessions.
+- Added support to clone, refresh and restore a volume group. 
+
 ## Version 1.6.0 - released on 28/06/2022
 - Added CRUD operations for LDAP domain and LDAP account.
 - Added execution environment manifest file to support building an execution environment with ansible-builder.

--- a/README.md
+++ b/README.md
@@ -2,19 +2,31 @@
 The Ansible Modules for Dell Technologies (Dell) PowerStore allow Data Center and IT administrators to use RedHat Ansible to automate and orchestrate the configuration and management of Dell PowerStore arrays.
 
 The capabilities of the Ansible modules are managing volumes, volume groups, hosts, host groups, snapshots, snapshot rules, replication rules, replication sessions, protection policies, file systems, NAS servers, SMB shares, user and tree quotas, file system snapshots, NFS exports, Clusters, Networks, Local users, Jobs, Roles, Certificates, Remote systems, security configuration, DNS server, Email notification destination, NTP server, Remote support configuration, Remote support contacts, SMTP configuration, LDAP accounts and LDAP domain configuration. It also allows gathering high level info from the array. The options available for each are list, show, create, modify and delete. These tasks can be executed by running simple playbooks written in yaml syntax. The modules are written so that all the operations are idempotent, so making multiple identical requests has the same effect as making a single request.
-## License
-Ansible collection for PowerStore is released and licensed under the GPL-3.0 license. See [LICENSE](https://github.com/dell/ansible-powerstore/blob/1.6.0/LICENSE) for the full terms. Ansible modules and modules utilities that are part of the Ansible collection for PowerStore are released and licensed under the Apache 2.0 license. See [MODULE-LICENSE](https://github.com/dell/ansible-powerstore/blob/1.6.0/MODULE-LICENSE) for the full terms.
+## Table of contents
 
-## Support
-Ansible collections for PowerStore are supported by Dell and is provided under the terms of the license attached to the collection. Please see the [LICENSE](#license) for the full terms.
-Dell does not provide any support for the source code modifications.
-For any Ansible modules issues, questions or feedback, join the [Dell Automation Community](https://www.dell.com/community/Automation/bd-p/Automation).
+* [Code of conduct](https://github.com/dell/ansible-powerstore/blob/1.7.0/docs/CODE_OF_CONDUCT.md)
+* [Maintainer guide](https://github.com/dell/ansible-powerstore/blob/1.7.0/docs/MAINTAINER_GUIDE.md)
+* [Committer guide](https://github.com/dell/ansible-powerstore/blob/1.7.0/docs/COMMITTER_GUIDE.md)
+* [Contributing guide](https://github.com/dell/ansible-powerstore/blob/1.7.0/docs/CONTRIBUTING.md)
+* [Branching strategy](https://github.com/dell/ansible-powerstore/blob/1.7.0/docs/BRANCHING.md)
+* [List of adopters](https://github.com/dell/ansible-powerstore/blob/1.7.0/docs/ADOPTERS.md)
+* [Maintainers](https://github.com/dell/ansible-powerstore/blob/1.7.0/docs/MAINTAINERS.md)
+* [Support](https://github.com/dell/ansible-powerstore/blob/1.7.0/docs/SUPPORT.md)
+* [License](#license)
+* [Security](https://github.com/dell/ansible-powerstore/blob/1.7.0/docs/SECURITY.md)
+* [Prerequisites](#prerequisites)
+* [List of Ansible modules for Dell PowerStore](#list-of-ansible-modules-for-dell-powerstore)
+* [Installation and execution of Ansible modules for Dell PowerStore](#installation-and-execution-of-ansible-modules-for-dell-powerstore)
+* [Maintenance](#maintenance)
+
+## License
+The Ansible collection for PowerStore is released and licensed under the GPL-3.0 license. See [LICENSE](https://github.com/dell/ansible-powerstore/blob/1.7.0/LICENSE) for the full terms. Ansible modules and modules utilities that are part of the Ansible collection for PowerStore are released and licensed under the Apache 2.0 license. See [MODULE-LICENSE](https://github.com/dell/ansible-powerstore/blob/1.7.0/MODULE-LICENSE) for the full terms.
 
 ## Prerequisites
 
    | **Ansible Modules** | **PowerStore Version** | **Red Hat Enterprise Linux**| **SDK version** | **Python version** | **Ansible**              |
 |---------------------|-----------------------|------------------------------|-----------------|--------------------|--------------------------|
-| v1.6.0              | 1.x <br> 2.0 <br> 2.1 |7.9 <br> 8.4 <br> 8.5| 1.7.0           | 3.8.x <br> 3.9.x <br> 3.10.x | 2.11 <br> 2.12 <br> 2.13 |
+| v1.7.0              | 2.0.x <br> 2.1.x <br> 3.0.x |7.9 <br> 8.4 <br> 8.5| 1.8.0           | 3.8.x <br> 3.9.x <br> 3.10.x | 2.11 <br> 2.12 <br> 2.13 |
 
 
   * Please follow PyPowerStore installation instructions on [PyPowerStore Documentation](https://github.com/dell/python-powerstore)
@@ -23,128 +35,41 @@ For any Ansible modules issues, questions or feedback, join the [Dell Automation
 The modules are written in such a way that all requests are idempotent and hence fault-tolerant. It essentially means that the result of a successfully performed request is independent of the number of times it is executed.
 
 ## List of Ansible Modules for Dell PowerStore
-* [Volume module](https://github.com/dell/ansible-powerstore/blob/1.6.0/docs/Product%20Guide.md#volume-module)
-* [Volume group module](https://github.com/dell/ansible-powerstore/blob/1.6.0/docs/Product%20Guide.md#volume-group-module)
-* [Host module](https://github.com/dell/ansible-powerstore/blob/1.6.0/docs/Product%20Guide.md#host-module)
-* [Host group module](https://github.com/dell/ansible-powerstore/blob/1.6.0/docs/Product%20Guide.md#host-group-module)
-* [Snapshot module](https://github.com/dell/ansible-powerstore/blob/1.6.0/docs/Product%20Guide.md#snapshot-module)
-* [Snapshot rule module](https://github.com/dell/ansible-powerstore/blob/1.6.0/docs/Product%20Guide.md#snapshot-rule-module)
-* [Replication rule module](https://github.com/dell/ansible-powerstore/blob/1.6.0/docs/Product%20Guide.md#replication-rule-module)
-* [Replication session module](https://github.com/dell/ansible-powerstore/blob/1.6.0/docs/Product%20Guide.md#replication-session-module)
-* [Protection policy module](https://github.com/dell/ansible-powerstore/blob/1.6.0/docs/Product%20Guide.md#protection-policy-module)
-* [Info module](https://github.com/dell/ansible-powerstore/blob/1.6.0/docs/Product%20Guide.md#info-module)
-* [File system module](https://github.com/dell/ansible-powerstore/blob/1.6.0/docs/Product%20Guide.md#file-system-module)
-* [NAS server module](https://github.com/dell/ansible-powerstore/blob/1.6.0/docs/Product%20Guide.md#nas-server-module)
-* [SMB share module](https://github.com/dell/ansible-powerstore/blob/1.6.0/docs/Product%20Guide.md#smb-share-module)
-* [Quota module](https://github.com/dell/ansible-powerstore/blob/1.6.0/docs/Product%20Guide.md#quota-module)
-* [File system snapshot module](https://github.com/dell/ansible-powerstore/blob/1.6.0/docs/Product%20Guide.md#filesystem-snapshot-module)
-* [NFS export module](https://github.com/dell/ansible-powerstore/blob/1.6.0/docs/Product%20Guide.md#nfs-export-module)
-* [Cluster module](https://github.com/dell/ansible-powerstore/blob/1.6.0/docs/Product%20Guide.md#cluster-module)
-* [Network module](https://github.com/dell/ansible-powerstore/blob/1.6.0/docs/Product%20Guide.md#network-module)
-* [Local user module](https://github.com/dell/ansible-powerstore/blob/1.6.0/docs/Product%20Guide.md#local-user-module)
-* [Role module](https://github.com/dell/ansible-powerstore/blob/1.6.0/docs/Product%20Guide.md#role-module)
-* [Job module](https://github.com/dell/ansible-powerstore/blob/1.6.0/docs/Product%20Guide.md#job-module)
-* [Certificate module](https://github.com/dell/ansible-powerstore/blob/1.6.0/docs/Product%20Guide.md#certificate-module)
-* [Remote system module](https://github.com/dell/ansible-powerstore/blob/1.6.0/docs/Product%20Guide.md#remote-system-module)
-* [Security config module](https://github.com/dell/ansible-powerstore/blob/1.6.0/docs/Product%20Guide.md#security-config-module)
-* [DNS module](https://github.com/dell/ansible-powerstore/blob/1.6.0/docs/Product%20Guide.md#dns-module)
-* [Email module](https://github.com/dell/ansible-powerstore/blob/1.6.0/docs/Product%20Guide.md#email-module)
-* [NTP module](https://github.com/dell/ansible-powerstore/blob/1.6.0/docs/Product%20Guide.md#ntp-module)
-* [Remote support module](https://github.com/dell/ansible-powerstore/blob/1.6.0/docs/Product%20Guide.md#remote-support-module)
-* [Remote support contact module](https://github.com/dell/ansible-powerstore/blob/1.6.0/docs/Product%20Guide.md#remote-support-contact-module)
-* [SMTP config module](https://github.com/dell/ansible-powerstore/blob/1.6.0/docs/Product%20Guide.md#smtp-config-module)
-* [LDAP Account module](https://github.com/dell/ansible-powerstore/blob/1.6.0/docs/Product%20Guide.md#ldap-account-module)
-* [LDAP Domain module](https://github.com/dell/ansible-powerstore/blob/1.6.0/docs/Product%20Guide.md#ldap-domain-module)
-## Installation of SDK
-* Install the python SDK named [PyPowerStore](https://pypi.org/project/PyPowerStore/). It can be installed using pip, based on appropriate python version. Execute this command:
+* [Volume module](https://github.com/dell/ansible-powerstore/blob/1.7.0/docs/Product%20Guide.md#volume-module)
+* [Volume group module](https://github.com/dell/ansible-powerstore/blob/1.7.0/docs/Product%20Guide.md#volume-group-module)
+* [Host module](https://github.com/dell/ansible-powerstore/blob/1.7.0/docs/Product%20Guide.md#host-module)
+* [Host group module](https://github.com/dell/ansible-powerstore/blob/1.7.0/docs/Product%20Guide.md#host-group-module)
+* [Snapshot module](https://github.com/dell/ansible-powerstore/blob/1.7.0/docs/Product%20Guide.md#snapshot-module)
+* [Snapshot rule module](https://github.com/dell/ansible-powerstore/blob/1.7.0/docs/Product%20Guide.md#snapshot-rule-module)
+* [Replication rule module](https://github.com/dell/ansible-powerstore/blob/1.7.0/docs/Product%20Guide.md#replication-rule-module)
+* [Replication session module](https://github.com/dell/ansible-powerstore/blob/1.7.0/docs/Product%20Guide.md#replication-session-module)
+* [Protection policy module](https://github.com/dell/ansible-powerstore/blob/1.7.0/docs/Product%20Guide.md#protection-policy-module)
+* [Info module](https://github.com/dell/ansible-powerstore/blob/1.7.0/docs/Product%20Guide.md#info-module)
+* [File system module](https://github.com/dell/ansible-powerstore/blob/1.7.0/docs/Product%20Guide.md#file-system-module)
+* [NAS server module](https://github.com/dell/ansible-powerstore/blob/1.7.0/docs/Product%20Guide.md#nas-server-module)
+* [SMB share module](https://github.com/dell/ansible-powerstore/blob/1.7.0/docs/Product%20Guide.md#smb-share-module)
+* [Quota module](https://github.com/dell/ansible-powerstore/blob/1.7.0/docs/Product%20Guide.md#quota-module)
+* [File system snapshot module](https://github.com/dell/ansible-powerstore/blob/1.7.0/docs/Product%20Guide.md#filesystem-snapshot-module)
+* [NFS export module](https://github.com/dell/ansible-powerstore/blob/1.7.0/docs/Product%20Guide.md#nfs-export-module)
+* [Cluster module](https://github.com/dell/ansible-powerstore/blob/1.7.0/docs/Product%20Guide.md#cluster-module)
+* [Network module](https://github.com/dell/ansible-powerstore/blob/1.7.0/docs/Product%20Guide.md#network-module)
+* [Local user module](https://github.com/dell/ansible-powerstore/blob/1.7.0/docs/Product%20Guide.md#local-user-module)
+* [Role module](https://github.com/dell/ansible-powerstore/blob/1.7.0/docs/Product%20Guide.md#role-module)
+* [Job module](https://github.com/dell/ansible-powerstore/blob/1.7.0/docs/Product%20Guide.md#job-module)
+* [Certificate module](https://github.com/dell/ansible-powerstore/blob/1.7.0/docs/Product%20Guide.md#certificate-module)
+* [Remote system module](https://github.com/dell/ansible-powerstore/blob/1.7.0/docs/Product%20Guide.md#remote-system-module)
+* [Security config module](https://github.com/dell/ansible-powerstore/blob/1.7.0/docs/Product%20Guide.md#security-config-module)
+* [DNS module](https://github.com/dell/ansible-powerstore/blob/1.7.0/docs/Product%20Guide.md#dns-module)
+* [Email module](https://github.com/dell/ansible-powerstore/blob/1.7.0/docs/Product%20Guide.md#email-module)
+* [NTP module](https://github.com/dell/ansible-powerstore/blob/1.7.0/docs/Product%20Guide.md#ntp-module)
+* [Remote support module](https://github.com/dell/ansible-powerstore/blob/1.7.0/docs/Product%20Guide.md#remote-support-module)
+* [Remote support contact module](https://github.com/dell/ansible-powerstore/blob/1.7.0/docs/Product%20Guide.md#remote-support-contact-module)
+* [SMTP config module](https://github.com/dell/ansible-powerstore/blob/1.7.0/docs/Product%20Guide.md#smtp-config-module)
+* [LDAP Account module](https://github.com/dell/ansible-powerstore/blob/1.7.0/docs/Product%20Guide.md#ldap-account-module)
+* [LDAP Domain module](https://github.com/dell/ansible-powerstore/blob/1.7.0/docs/Product%20Guide.md#ldap-domain-module)
 
-        pip install PyPowerStore
-* Alternatively, Clone the repo "https://github.com/dell/python-powerstore"
-   using command:
-   
-        git clone https://github.com/dell/python-powerstore.git
-    * Go to the root directory of setup.
-    * Execute this command:
-      
-            pip install .
-
-## Building Collections
-  * Use this command to build the collection from source code:
-
-        ansible-galaxy collection build
-
-  For more details on how to build a tar ball, please refer: [Building the collection](https://docs.ansible.com/ansible/latest/dev_guide/developing_collections_distributing.html#building-your-collection-tarball)
-
-## Installing Collections
-#### Online Installation of Collections 
-  1. Use this command to install the latest collection hosted in galaxy:
-
-	     ansible-galaxy collection install dellemc.powerstore -p <install_path>
-
-#### Offline Installation of Collections
-  1. Download the latest tar build from any of the available distribution channel [Ansible Galaxy](https://galaxy.ansible.com/dellemc/powerstore) /[Automation Hub](https://console.redhat.com/ansible/automation-hub/repo/published/dellemc/powerstore) and use this command to install the collection anywhere in your system:
-
-
-	     ansible-galaxy collection install dellemc-powerstore-1.6.0.tar.gz -p <install_path>
-
-
-  2. Set the environment variable:
-
-	     export ANSIBLE_COLLECTIONS_PATHS=$ANSIBLE_COLLECTIONS_PATHS:<install_path>
-
-## Using Collections
-  1. In order to use any Ansible module, ensure that the importing of a proper FQCN (Fully Qualified Collection Name) must be embedded in the playbook. Refer to this example:
-
-	     collections:
-	     - dellemc.powerstore
-
-  2. In order to use an installed collection specific to the task use a proper FQCN (Fully Qualified Collection Name). Refer to this example:
-
-	     tasks:
-         - name: Get Volume details
-	       dellemc.powerstore.volume
-
-  3. For generating Ansible documentation for a specific module, embed the FQCN  before the module name. Refer to this example:
-
-	     ansible-doc dellemc.powerstore.info
-
-## Running Ansible Modules
-The Ansible server must be configured with Python library for PowerStore to run the Ansible playbooks. The [Documents](https://github.com/dell/ansible-powerstore/tree/1.6.0/docs) provide information on different Ansible modules along with their functions and syntax. The parameters table in the Product Guide provides information on various parameters which needs to be configured before running the modules.
-
-## SSL Certificate Validation
- 1. Copy the CA certificate to this "/etc/pki/ca-trust/source/anchors" path of the host by any external means.
- 2. Set the "REQUESTS_CA_BUNDLE" environment variable to the path of the SSL certificate using this command:
-	
-		export REQUESTS_CA_BUNDLE=/etc/pki/ca-trust/source/anchors/<<Certificate_Name>>
-	
- 3. Import the SSL certificate to host using this command:
-
-		update-ca-trust
-
-## Results
-Each module returns the updated state and details of the entity. 
-For example, if you are using the cluster module, all calls will return the updated details of the cluster.
-Sample result is shown in each module's documentation.
-
-
-## Ansible Execution Environment
-Ansible can also be installed in a container environment. Ansible Builder provides the ability to create reproducible, self-contained environments as container images that can be run as Ansible execution environments.
-* Install the ansible builder package using:
-
-       pip3 install ansible-builder
-* Create the execution environment using:
-
-       ansible-builder build --tag <tag_name> --container-runtime docker
-* After the image is built, run the container using:
-
-       docker run -it <tag_name> /bin/bash
-* Verify collection installation using command:
-
-       ansible-galaxy collection list
-* The playbook can be run on the container using:
-
-      docker run --rm -v $(pwd):/runner <tag_name> ansible-playbook info_test.yml
-
+## Installation and execution of Ansible modules for Dell PowerStore
+The installation and execution steps of Ansible modules for Dell PowerStore can be found [here](https://github.com/dell/ansible-powerstore/blob/1.7.0/docs/INSTALLATION.md)
 
 ## Maintenance
 Ansible Modules for Dell Technologies PowerStore deprecation cycle is aligned with [Ansible](https://docs.ansible.com/ansible/latest/dev_guide/module_lifecycle.html).

--- a/docs/ADOPTERS.md
+++ b/docs/ADOPTERS.md
@@ -1,0 +1,11 @@
+<!--
+Copyright (c) 2022 Dell Inc., or its subsidiaries. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+-->
+
+# List of adopters

--- a/docs/BRANCHING.md
+++ b/docs/BRANCHING.md
@@ -1,0 +1,32 @@
+<!--
+Copyright (c) 2022 Dell Inc., or its subsidiaries. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+-->
+
+# Branching strategy
+
+Ansible modules for Dell PowerStore follows a scaled trunk branching strategy where short-lived branches are created off of the main branch. When coding is complete, the branch is merged back into main after being approved in a pull request code review.
+
+## Branch naming convention
+
+|  Branch Type |  Example                          |  Comment                                  |
+|--------------|-----------------------------------|-------------------------------------------|
+|  master      |  master                           |                                           |
+|  Release     |  release-1.0                      |  hotfix: release-1.1 patch: release-1.0.1 |
+|  Feature     |  feature-9-vol-support            |  "9" referring to GitHub issue ID         |
+|  Bug Fix     |  bugfix-110-fix-duplicates-issue  |  "110" referring to GitHub issue ID       |
+
+
+## Steps for working on a release branch
+
+1. Fork the repository.
+2. Create a branch off of the master branch. The branch name should follow [branch naming convention](#branch-naming-convention).
+3. Make your changes and commit them to your branch.
+4. If other code changes have merged into the upstream master branch, perform a rebase of those changes into your branch.
+5. Open a [pull request](https://github.com/dell/ansible-powerstore/pulls) between your branch and the upstream master branch.
+6. Once your pull request has merged, your branch can be deleted.

--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -1,0 +1,137 @@
+<!--
+Copyright (c) 2022 Dell Inc., or its subsidiaries. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+-->
+
+# Code of conduct - contributor covenant
+
+## Our pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at ansible.team@dell.com
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary ban
+
+**Community impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent ban
+
+**Community impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/docs/COMMITTER_GUIDE.md
+++ b/docs/COMMITTER_GUIDE.md
@@ -1,0 +1,49 @@
+<!--
+Copyright (c) 2022 Dell Inc., or its subsidiaries. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+-->
+
+# Committer guidelines
+
+These are the guidelines for people with commit privileges on the GitHub repository. Committers act as members of the Core Team and not necessarily employees of Dell.
+
+These guidelines apply to everyone and as Committers you have been given access to commit changes because you exhibit good judgment and have demonstrated your commitment to the vision of the project. We trust that you will use these privileges wisely and not abuse it.
+
+If these privileges are abused in any way and the quality of the project is compromised, our trust will be diminished and you may be asked to not commit or lose these privileges all together.
+
+## General rules
+
+### Don't
+
+* Break the build.
+* Commit directly.
+* Compromise backward compatibility.
+* Disrespect your Community Team members. Help them grow.
+* Think it is someone elses job to test your code. Write tests for all the code you produce.
+* Forget to keep thing simple.
+* Create technical debt. Fix-in-place and make it the highest priority above everything else.
+
+### Do
+
+* Keep it simple.
+* Good work, your best every time.
+* Keep the design of your software clean and maintainable.
+* Squash your commits, avoid merges.
+* Be active. Committers that are not active may have their permissions suspended.
+* Write tests for all your deliverables.
+* Automate everything.
+* Maintain a high code coverage.
+* Keep an open communication with other Committers.
+* Ask questions.
+* Document your contributions and remember to keep it simple.
+
+## People
+
+| Name  |  GitHub ID  |  Nickname  |
+|-------|-------------|------------|
+|       |             |            |

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,173 @@
+<!--
+Copyright (c) 2022 Dell Inc., or its subsidiaries. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+-->
+
+# How to contribute
+
+Become one of the contributors to this project! We thrive to build a welcoming and open community for anyone who wants to use the project or contribute to it. There are just a few small guidelines you need to follow. To help us create a safe and positive community experience for all, we require all participants to adhere to the [Code of Conduct](https://github.com/dell/ansible-powerstore/blob/1.7.0/docs/CODE_OF_CONDUCT.md).
+
+## Table of contents
+
+* [Become a contributor](#Become-a-contributor)
+* [Submitting issues](#Submitting-issues)
+* [Triage issues](#Triage-issues)
+* [Your first contribution](#Your-first-contribution)
+* [Branching](#Branching)
+* [Signing your commits](#Signing-your-commits)
+* [Pull requests](#Pull-requests)
+* [Code reviews](#Code-reviews)
+* [TODOs in the code](#TODOs-in-the-code)
+
+## Become a contributor
+
+You can contribute to this project in several ways. Here are some examples:
+
+* Contribute to the Ansible modules for Dell PowerStore documentation and codebase.
+* Report and triage bugs.
+* Feature requests.
+* Write technical documentation and blog posts, for users and contributors.
+* Help others by answering questions about this project.
+
+## Submitting issues
+
+All issues related to Ansible modules for Dell PowerStore, regardless of the service/repository the issue belongs to (see table above), should be submitted [here](https://github.com/dell/ansible-powerstore/issues). Issues will be triaged and labels will be used to indicate the type of issue. This section outlines the types of issues that can be submitted.  
+
+### Report bugs
+
+We aim to track and document everything related to Ansible modules for Dell PowerStore via the Issues page. The code and documentation are released with no warranties or SLAs and are intended to be supported through a community driven process.
+
+Before submitting a new issue, make sure someone hasn't already reported the problem. Look through the [existing issues](https://github.com/dell/ansible-powerstore/issues) for similar issues.
+
+Report a bug by submitting a [bug report](https://github.com/dell/ansible-powerstore/issues/new?labels=type%2Fbug%2C+needs-triage&template=bug_report.md&title=%5BBUG%5D%3A). Make sure that you provide as much information as possible on how to reproduce the bug.
+
+When opening a Bug please include this information to help with debugging:
+
+1. Version of relevant software: this software, Ansible, Python, SDK, etc.
+2. Details of the issue explaining the problem: what, when, where
+3. The expected outcome that was not met (if any)
+4. Supporting troubleshooting information. __Note: Do not provide private company information that could compromise your company's security.__
+
+An Issue __must__ be created before submitting any pull request. Any pull request that is created should be linked to an Issue.
+
+### Feature request
+
+If you have an idea of how to improve this project, submit a [feature request](https://github.com/dell/ansible-powerstore/issues/new?labels=type%2Ffeature-request%2C+needs-triage&template=feature_request.md&title=%5BFEATURE%5D%3A).
+
+### Answering questions
+
+If you have a question and you can't find the answer in the documentation or issues, the next step is to submit a [question.](https://github.com/dell/ansible-powerstore/issues/new?labels=type%2Fquestion&template=ask-a-question.md&title=%5BQUESTION%5D%3A)
+
+We'd love your help answering questions being asked by other Ansible modules for Dell PowerStore users.
+
+## Triage issues
+
+Triage helps ensure that issues resolve quickly by:
+
+* Ensuring the issue's intent and purpose is conveyed precisely. This is necessary because it can be difficult for an issue to explain how an end user experiences a problem and what actions they took.
+* Giving a contributor the information they need before they commit to resolving an issue.
+* Lowering the issue count by preventing duplicate issues.
+* Streamlining the development process by preventing duplicate discussions.
+
+If you don't have the knowledge or time to code, consider helping with _issue triage_. The Ansible modules for Dell PowerStore community will thank you for saving them time by spending some of yours.
+
+Read more about the ways you can [Triage issues](https://github.com/dell/ansible-powerstore/blob/1.7.0/docs/ISSUE_TRIAGE.md).
+
+## Your first contribution
+
+Unsure where to begin contributing? Start by browsing issues labeled `beginner friendly` or `help wanted`.
+
+* [Beginner-friendly](https://github.com/dell/ansible-powerstore/issues?q=is%3Aopen+is%3Aissue+label%3A%22beginner+friendly%22) issues are generally straightforward to complete.
+* [Help wanted](https://github.com/dell/ansible-powerstore/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22) issues are problems we would like the community to help us with regardless of complexity.
+
+When you're ready to contribute, it's time to create a pull request.
+
+## Branching
+
+* [Branching Strategy for Ansible modules for Dell PowerStore](https://github.com/dell/ansible-powerstore/blob/1.7.0/docs/BRANCHING.md)
+
+## Signing your commits
+
+We require that developers sign off their commits to certify that they have permission to contribute the code in a pull request. This way of certifying is commonly known as the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). We encourage all contributors to read the DCO text before signing a commit and making contributions.
+
+GitHub will prevent a pull request from being merged if there are any unsigned commits.
+
+### Signing a commit
+
+GPG (GNU Privacy Guard) will be used to sign commits.  Follow the instructions [here](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/signing-commits) to create a GPG key and configure your GitHub account to use that key.
+
+Make sure you have your user name and e-mail set.  This will be required for your signed commit to be properly verified.  Check this references:
+
+* Setting up your github user name [reference](https://help.github.com/articles/setting-your-username-in-git/)
+* Setting up your e-mail address [reference](https://help.github.com/articles/setting-your-commit-email-address-in-git/)
+
+Once Git and your GitHub account have been properly configured, you can add the -S flag to the git commits:
+
+```console
+$ git commit -S -m your commit message
+# Creates a signed commit
+```
+
+### Commit message format
+
+Ansible modules for Dell PowerStore uses the guidelines for commit messages outlined in [How to Write a Git Commit Message](https://chris.beams.io/posts/git-commit/)
+
+## Pull requests
+
+If this is your first time contributing to an open-source project on GitHub, make sure you read about [Creating a pull request](https://help.github.com/en/articles/creating-a-pull-request).
+
+A pull request must always link to at least one GitHub issue. If that is not the case, create a GitHub issue and link it.
+
+To increase the chance of having your pull request accepted, make sure your pull request follows these guidelines:
+
+* Title and description matches the implementation.
+* Commits within the pull request follow the formatting guidelines.
+* The pull request closes one related issue.
+* The pull request contains necessary tests that verify the intended behavior.
+* If your pull request has conflicts, rebase your branch onto the main branch.
+
+If the pull request fixes a bug:
+
+* The pull request description must include `Fixes #<issue number>`.
+* To avoid regressions, the pull request should include tests that replicate the fixed bug.
+
+The team _squashes_ all commits into one when we accept a pull request. The title of the pull request becomes the subject line of the squashed commit message. We still encourage contributors to write informative commit messages, as they becomes a part of the Git commit body.
+
+We use the pull request title when we generate change logs for releases. As such, we strive to make the title as informative as possible.
+
+Make sure that the title for your pull request uses the same format as the subject line in the commit message.
+
+### Quality gates for pull requests
+
+GitHub Actions are used to enforce quality gates when a pull request is created or when any commit is made to the pull request. These GitHub Actions enforce our minimum code quality requirement for any code that get checked into the repository. If any of the quality gates fail, it is expected that the contributor will look into the check log, understand the problem and resolve the issue. If help is needed, please feel free to reach out the maintainers of the project for [support](https://github.com/dell/ansible-powerstore/blob/1.7.0/docs/SUPPORT.md).
+
+#### Code sanitization
+
+[GitHub action](https://github.com/dell/ansible-powerstore/actions/workflows/ansible-test.yml) that analyzes source code to flag ansible sanity errors and runs Unit tests.
+
+## Code reviews
+
+All submissions, including submissions by project members, require review. We use GitHub pull requests for this purpose. Consult [GitHub Help](https://help.github.com/articles/about-pull-requests/) for more information on using pull requests.
+
+A pull request must satisfy following for it to be merged:
+
+* A pull request will require at least 2 maintainer approvals.
+* Maintainers must perform a review to ensure the changes adhere to guidelines laid out in this document.
+* If any commits are made after the PR has been approved, the PR approval will automatically be removed and the above process must happen again.
+
+## Code style
+
+Ensure the added code has the required documenation, examples and unit tests.
+
+### Sanity
+
+Run ansible-test sanity --docker default on your code to ensure sanity. Ensure the code does not have any Andersson script violations and not break any existing unit test workflows.
+
+### TODOs in the code
+
+We don't like TODOs in the code or documentation. It is really best if you sort out all issues you can see with the changes before we check the changes in.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,0 +1,106 @@
+<!--
+Copyright (c) 2022 Dell Inc., or its subsidiaries. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+-->
+
+# Installation and execution of Ansible modules for Dell PowerStore
+
+## Installation of SDK
+* Install the python SDK named [PyPowerStore](https://pypi.org/project/PyPowerStore/). It can be installed using pip, based on appropriate python version. Execute this command:
+
+        pip install PyPowerStore
+* Alternatively, Clone the repo "https://github.com/dell/python-powerstore"
+   using command:
+   
+        git clone https://github.com/dell/python-powerstore.git
+    * Go to the root directory of setup.
+    * Execute this command:
+      
+            pip install .
+
+## Building collections
+  * Use this command to build the collection from source code:
+
+        ansible-galaxy collection build
+
+   For more details on how to build a tar ball, please refer to: [Building the collection](https://docs.ansible.com/ansible/latest/dev_guide/developing_collections_distributing.html#building-your-collection-tarball)
+
+## Installing collections
+
+#### Online installation of collections
+  * Use this command to install the latest collection hosted in [galaxy portal](https://galaxy.ansible.com/dellemc/powerstore):
+
+        ansible-galaxy collection install dellemc.powerstore -p <install_path>
+
+#### Offline installation of collections
+
+  * Download the latest tar build from any of the available distribution channel [Ansible Galaxy](https://galaxy.ansible.com/dellemc/powerstore) /[Automation Hub](https://console.redhat.com/ansible/automation-hub/repo/published/dellemc/powerstore) and use this command to install the collection anywhere in your system:
+ 
+        ansible-galaxy collection install dellemc-powerstore-1.7.0.tar.gz -p <install_path>
+
+  * Set the environment variable:
+  
+        export ANSIBLE_COLLECTIONS_PATHS=$ANSIBLE_COLLECTIONS_PATHS:<install_path>
+ 
+## Using collections
+
+  * In order to use any Ansible module, ensure that the importing of proper FQCN (Fully Qualified Collection Name) must be embedded in the playbook.
+   This example can be referred to:
+ 
+        collections:
+        - dellemc.powerstore
+
+  * In order to use installed collection in a specific task use a proper FQCN (Fully Qualified Collection Name). Refer to this example:
+
+        tasks:
+        - name: Get Volume details
+          dellemc.powerstore.volume
+    
+  * For generating Ansible documentation for a specific module, embed the FQCN  before the module name. Refer to this example:
+        
+        ansible-doc dellemc.powerstore.volume
+
+
+## Ansible modules execution
+
+The Ansible server must be configured with Python library for PowerStore to run the Ansible playbooks. The [Documents](https://github.com/dell/ansible-powerstore/blob/1.7.0/docs/) provide information on different Ansible modules along with their functions and syntax. The parameters table in the Product Guide provides information on various parameters which needs to be configured before running the modules.
+
+## SSL certificate validation
+
+* Copy the CA certificate to the "/etc/pki/ca-trust/source/anchors" path of the host by any external means.
+* Set the "REQUESTS_CA_BUNDLE" environment variable to the path of the SSL certificate using the command:
+
+        export REQUESTS_CA_BUNDLE=/etc/pki/ca-trust/source/anchors/<<Certificate_Name>>
+* Import the SSL certificate to host using the command:
+
+        update-ca-trust extract
+* If "TLS CA certificate bundle error" occurs, then follow these steps:
+
+        cd /etc/pki/tls/certs/
+        openssl x509 -in ca-bundle.crt -text -noout    
+
+## Results
+Each module returns the updated state and details of the entity, For example, if you are using the Volume module, all calls will return the updated details of the volume. Sample result is shown in each module's documentation.
+
+## Ansible execution environment
+Ansible can also be installed in a container environment. Ansible Builder provides the ability to create reproducible, self-contained environments as container images that can be run as Ansible execution environments.
+* Install the ansible builder package using:
+
+      pip3 install ansible-builder
+* Ensure the execution-environment.yml is at the root of collection and create the execution environment using:
+
+      ansible-builder build --tag <tag_name> --container-runtime docker
+* After the image is built, run the container using:
+
+      docker run -it <tag_name> /bin/bash
+* Verify collection installation using command:
+
+      ansible-galaxy collection list
+* The playbook can be run on the container using:
+
+      docker run --rm -v $(pwd):/runner <tag_name> ansible-playbook info_test.yml

--- a/docs/ISSUE_TRIAGE.md
+++ b/docs/ISSUE_TRIAGE.md
@@ -1,0 +1,308 @@
+<!--
+Copyright (c) 2022 Dell Inc., or its subsidiaries. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+-->
+
+# Triage issues
+
+The main goal of issue triage is to categorize all incoming issues and make sure each issue has all basic information needed for anyone else to understand and be able to start working on it.
+
+> **Note:** This information is for project Maintainers, Owners, and Admins. If you are a Contributor, then you will not be able to perform most of the tasks in this topic.
+
+The core maintainers of this project are responsible for categorizing all incoming issues and delegating any critical or important issue to other maintainers. Triage provides an important way to contribute to an open source project.
+
+Triage helps ensure issues resolve quickly by:
+
+- Ensuring the issue's intent and purpose is conveyed precisely. This is necessary because it can be difficult for an issue to explain how an end user experiences a problem and what actions they took.
+- Giving a contributor the information they need before they commit to resolving an issue.
+- Lowering the issue count by preventing duplicate issues.
+- Streamlining the development process by preventing duplicate discussions.
+
+If you don't have the knowledge or time to code, consider helping with triage. The community will thank you for saving them time by spending some of yours.
+
+## 1. Find issues that need triage
+
+The easiest way to find issues that haven't been triaged is to search for issues with the `needs-triage` label.
+
+## 2. Ensure the issue contains basic information
+
+Make sure that the issue's author provided the standard issue information. This project utilizes GitHub issue templates to guide contributors to provide standard information that must be included for each type of template or type of issue.
+
+### Standard issue information that must be included
+
+This section describes the various issue templates and the expected content.
+
+#### Bug reports
+
+Should explain what happened, what was expected and how to reproduce it together with any additional information that may help giving a complete picture of what happened such as screenshots, output and any environment related information that's applicable and/or maybe related to the reported problem:
+
+ - Ansible Version: [e.g. 2.13]
+ - Python Version [e.g. 3.10]
+ - Ansible modules for Dell PowerStore Version: [e.g. 1.7.0]
+ - PowerStore SDK version: [e.g. PyPowerStore 1.8.0]
+ - Any other additional information...
+
+#### Feature requests
+
+Should explain what feature that the author wants to be added and why that is needed.
+
+#### Ask a question requests
+
+In general, if the issue description and title is perceived as a question no more information is needed.
+
+### Good practices
+
+To make it easier for everyone to understand and find issues they're searching for it's suggested as a general rule of thumbs to:
+
+- Make sure that issue titles are named to explain the subject of the issue, has a correct spelling and doesn't include irrelevant information and/or sensitive information.
+- Make sure that issue descriptions doesn't include irrelevant information.
+- Make sure that issues do not contain sensitive information.
+- Make sure that issues have all relevant fields filled in.
+- Do your best effort to change title and description or request suggested changes by adding a comment.
+
+> **Note:** Above rules are applicable to both new and existing issues.
+
+### Dealing with missing information
+
+Depending on the issue, you might not feel all this information is needed. Use your best judgement. If you cannot triage an issue using what its author provided, explain kindly to the author that they must provide the above information to clarify the problem. Label issue with `triage/needs-information`.
+
+If the author provides the standard information but you are still unable to triage the issue, request additional information. Do this kindly and politely because you are asking for more of the author's time.  Label issue with `triage/needs-information`.
+
+If the author does not respond to the requested information within the timespan of a week, close the issue with a kind note stating that the author can request for the issue to be reopened when the necessary information is provided.
+
+If you receive a notification with additional information provided but you are not anymore on issue triage and you feel you do not have time to handle it, you should delegate it to the current person on issue triage.
+
+## 3. Categorizing an issue
+
+### Duplicate issues
+
+Make sure it's not a duplicate by searching existing issues using related terms from the issue title and description. If you think you know there is an existing issue, but can't find it, please reach out to one of the maintainers and ask for help. If you identify that the issue is a duplicate of an existing issue:
+
+1. Add a comment `duplicate of #<issue number>`
+2. Add the `triage/duplicate` label
+
+### Bug reports
+
+If it's not perfectly clear that it's an actual bug, quickly try to reproduce it.
+
+**It's a bug/it can be reproduced:**
+
+1. Add a comment describing detailed steps for how to reproduce it, if applicable.
+2. If you know that maintainers wont be able to put any resources into it for some time then label the issue with `help wanted` and optionally `beginner friendly` together with pointers on which code to update to fix the bug. This should signal to the community that we would appreciate any help we can get to resolve this.
+3. Move on to [prioritizing the issue](#4-prioritization-of-issues).
+
+**It can't be reproduced:**
+
+1. Either [ask for more information](#2-ensure-the-issue-contains-basic-information) needed to investigate it more thoroughly.  Provide details in a comment.
+2. Either [delegate further investigations](#investigation-of-issues) to someone else.  Provide details in a comment.
+
+**It works as intended/by design:**
+
+1. Kindly and politely add a comment explaining briefly why we think it works as intended and close the issue.
+2. Label the issue `triage/works-as-intended`.
+3. Remove the `needs-triage` label.
+
+**It does not work as intended/by design:**
+
+### Feature requests
+
+1. If the feature request does not align with the product vision, add a comment indicating so, remove the `needs-triage` label and close the issue
+2. Otherwise, move on to [prioritizing the issue](#4-prioritization-of-issues).  Assign the appropriate priority label to the issue, add the appropriate comments to the issue, and remove the `needs-triage` label.
+
+## 4. Prioritization of issues
+
+In general bugs and feature request issues should be labeled with a priority.
+
+This is the most difficult thing with triaging issues since it requires a lot of knowledge, context and experience before being able to think of and start feel comfortable adding a certain priority label.
+
+The key here is asking for help and discuss issues to understand how more experienced project members think and reason. By doing that you learn more and eventually be more and more comfortable with prioritizing issues.
+
+In case there is an uncertainty around the prioritization of an issue, please ask the maintainers for help.
+
+| Label                             | Description                                                                                                              |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `priority/critical`               | Highest priority. Must be actively worked on as someone's top priority right now.                                        |
+| `priority/high`                   | Must be worked on soon, ideally in time for the next release.                                                            |
+| `priority/low`                    | Lowest priority. Possibly useful, but not yet enough interest in it.                                                     |
+
+### Critical priority
+
+1. If an issue has been categorized and any of this criteria apply, the issue should be labeled as critical and must be actively worked on as someone's top priority right now.
+
+   - Results in any data loss
+   - Critical security or performance issues
+   - Problem that makes a feature unusable
+   - Multiple users experience a severe problem affecting their business, users etc.
+
+2. Label the issue `priority/critical`.
+3. Escalate the problem to the maintainers.
+4. Assign or ask a maintainer for help assigning someone to make this issue their top priority right now.
+5. Add the issue to the next upcoming release milestone.
+
+### High priority
+
+1. Label the issue `priority/high`.
+2. Add the issue to the next upcoming release milestone.
+3. Prioritize it or assign someone to work on it now or very soon.
+4. Consider requesting [help from the community](#5-requesting-help-from-the-community).
+
+### Low priority
+
+1. If the issue is deemed possibly useful but a low priority label the issue `priority/low`.
+2. The amount of interest in the issue will determine if the priority changes to be higher.
+3. Consider requesting [help from the community](#5-requesting-help-from-the-community).
+
+## 5. Requesting help from the community
+
+Depending on the issue and/or priority, it's always a good idea to consider signalling to the community that help from community is appreciated and needed in case an issue is not prioritized to be worked on by maintainers. Use your best judgement. In general, requesting help from the community means that a contribution has a good chance of getting accepted and merged.
+
+In many cases the issue author or community as a whole is more suitable to contribute changes since they're experts in their domain. It's also quite common that someone has tried to get something to work using the documentation without success and made an effort to get it to work and/or reached out to the community to get the missing information.
+
+1. Kindly and politely add a comment to signal to users subscribed to updates of the issue.
+   - Explain that the issue would be nice to get resolved, but it isn't prioritized to work on by maintainers for an unforeseen future.
+   - If possible or applicable, try to help contributors getting starting by adding pointers and references to what code/files need to be changed and/or ideas of a good way to solve/implement the issue.
+2. Label the issue with `help wanted`.
+3. If applicable, label the issue with `beginner friendly` to denote that the issue is suitable for a beginner to work on.
+
+## Investigation of issues
+
+When an issue has all basic information provided, but the reported problem cannot be reproduced at a first glance, the issue is labeled `triage/needs-information`. Depending on the perceived severity and/or number of [upvotes](https://help.github.com/en/articles/about-conversations-on-github#reacting-to-ideas-in-comments), the investigation will either be delegated to another maintainer for further investigation or put on hold until someone else (maintainer or contributor) picks it up and eventually starts investigating it.
+
+Even if you don't have the time or knowledge to investigate an issue we highly recommend that you [upvote](https://help.github.com/en/articles/about-conversations-on-github#reacting-to-ideas-in-comments) the issue if you happen to have the same problem. If you have further details that may help investigating the issue please provide as much information as possible.
+
+## External pull requests
+
+Part of issue triage should also be triaging of external PRs. Main goal should be to make sure PRs from external contributors have an owner/reviewer and are not forgotten.
+
+1. Check new external PRs which do not have a reviewer.
+1. Check if there is a link to an existing issue.
+1. If not and you know which issue it is solving, add the link yourself, otherwise ask the author to link the issue or create one.
+1. Assign a reviewer based on who was handling the linked issue or what code or feature does the PR touches (look at who was the last to make changes there if all else fails).
+
+## GitHub issue management workflow
+
+This section describes the triage workflow for new GitGHub issues that get created.
+
+### GitHub Issue: Bug
+
+This workflow starts off with a GitHub issue of type bug being created.
+
+1. Collaborator or maintainer creates a GitHub bug using the appropriate GitHub issue template
+2. By default a bug will be created with the `type/bug` and `needs-triage` labels
+
+The following flow chart outlines the triage process for bugs.
+
+<!-- https://textik.com/#38ec14781648871c -->
+```
+                                               +--------------------------+                                                                              
+                                               | New bug issue opened/more|                                                                              
+                                               | information added        |                                                                              
+                                               +-------------|------------+                                                                              
+                                                             |                                                                                           
+                                                             |                                                                                           
+   +----------------------------------+  NO   +--------------|-------------+                                                                             
+   | label: triage/needs-information  ---------  All required information  |                                                                             
+   |                                  |       |  contained in issue?       |                                                                             
+   +-----------------------------|----+       +--------------|-------------+                                                                             
+                                 |                           | YES                                                                                       
+                                 |                           |                                                                                           
+   +--------------------------+  |                +---------------------+ YES +---------------------------------------+                                  
+   |label:                    |  |                |  Dupicate Issue?    ------- Comment `Duplicate of #<issue number>`                                   
+   |triage/needs-investigation|  | NO             |                     |     | Remove needs-triage label             |                                  
+   +------|-------------------+  |                +----------|----------+     | label: triage/duplicate               |                                  
+          |                      |                           | NO             +-----------------|---------------------+                                  
+      YES |                      |                           |                                  |                                                        
+          |      +---------------|----+   NO    +------------|------------+                     |                                                        
+          |      |Needs investigation?|----------  Can it be reproduced?  |                     |                                                        
+          |-------                    |         +------------|------------+                     |                                                        
+                 +--------------------+                      | YES                              |                                                        
+                                                             |                       +----------|----------+                                             
+    +-------------------------+                 +------------|------------+          |  Close Issue        |                                             
+    | Add release-found label |------------------  Works as intended?     |          |                     |                                             
+    | label: release-found/*  |        NO       |                         |          +----------|----------+                                             
+    +------------|------------+                 +------------|------------+                     |                                                        
+                 |                                           |                                  |                                                        
+                 |                                           | YES                              |                                                        
+    +-----------------------------+         +----------------|----------------+                 |                                                        
+    | Add area label              |         | Add comment                     |                 |                                                        
+    | label: area/*               |         | Remove needs-triage label       ------------------|                                                        
+    +------------|----------------+         | label: triage/works-as-intended |                                                                          
+                 |                          +---------------------------------+                                                                          
+                 |                                                                                                                                       
+    +------------|-------------+          +----------+                                                                                                   
+    | Add priority label       |          |   Done   ----------------------------------------                                                            
+    | label: priority/*        |          +----|-----+                                      |                                                            
+    +------------|-------------+               |NO                                          |                                                            
+                 |                             |                         +------------------|------------------+                                         
+    +------------|-------------+          +----|----------------+ YES    |  Add details to issue               |                                         
+    |                          ------------  Signal Community?  ----------  label: help wanted                 |                                         
+    |Remove needs-triage label |          |                     |        |  label: beginner friendly (optional)|                                         
+    +--------------------------+          +---------------------+        +-------------------------------------+                                         
+                                                                                                                                                                                            
+```
+
+If the author does not respond to a request for more information within the timespan of a week, close the issue with a kind note stating that the author can request for the issue to be reopened when the necessary information is provided.
+
+### GitHub issue: feature request
+
+This workflow starts off with a GitHub issue of type feature request being created.
+
+1. Collaborator or maintainer creates a GitHub feature request using the appropriate GitHub issue template
+2. By default a feature request will be created with the `type/feature-request` and `needs-triage` labels
+
+This flow chart outlines the triage process for feature requests.
+
+<!-- https://textik.com/#81e81fc717f63429 -->
+```
+                                            +---------------------------------+ 
+                                            |New feature request issue opened/| 
+                                            |more information added           | 
+                                            +----------------|----------------+ 
+                                                             |                  
+                                                             |                  
+    +---------------------------------+ NO     +-------------|------------+     
+    | label: triage/needs-information ---------- All required information |     
+    |                                 |        | contained in issue?      |     
+    +---------------------------------+        +-------------|------------+     
+                                                             |                  
+                                                             |                  
+    +---------------------------------------+                |                  
+    |Comment `Duplicate of #<issue number>` | YES +----------|----------+       
+    |Remove needs-triage label              -------  Duplicate issue?   |       
+    |label: triage/duplicate                |     |                     |       
+    +-----|---------------------------------+     +-----------|---------+       
+          |                                                   |NO               
+          |  +-------------------------+  NO   +-----------------------------+  
+          |  |Add comment              |--------  Does feature request align |  
+          |  |Remove needs-triage label|       |  with product vision?       |  
+          |  +------|------------------+       +--------------|--------------+  
+          |         |                                         | YES             
+          |         |                       +-----------------|----------------+
+          |         |                       |Change feature-request to feature |
+          |         |                       |Remove label: type/feature-request|
+          |         |                       |Add label: type/feature           |
+          |         |                       +-----------------|----------------+
+          |         |                                         |                 
+          |         |                          +--------------|--------------+  
+          |         |                          | Add area label              |  
+          |         |                          | label: area/*               |  
+          |         |                          +--------------|--------------+  
+          |         |                                         |                 
+        +-|---------|---+     +--------+       +--------------|--------------+  
+        |  Close issue  |     |  Done  --------- Add priority label          |  
+        |               |     |        |       | label: priority/*           |  
+        +---------------+     +--------+       +-----------------------------+                                                                               
+```
+
+If the author does not respond to a request for more information within the timespan of a week, close the issue with a kind note stating that the author can request for the issue to be reopened when the necessary information is provided.
+
+In some cases you may receive a request you do not wish to accept.  Perhaps the request doesn't align with the project scope or vision.  It is important to tactfully handle contributions that don't meet the project standards.
+
+1. Acknowledge the person behind the contribution and thank them for their interest and contribution
+2. Explain why it didn't fit into the scope of the project or vision
+3. Don't leave an unwanted contributions open.  Immediately close the contribution you do not wish to accept

--- a/docs/MAINTAINERS.md
+++ b/docs/MAINTAINERS.md
@@ -1,0 +1,17 @@
+<!--
+Copyright (c) 2022 Dell Inc., or its subsidiaries. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+-->
+
+# Maintainers
+
+* @ananthu-kuttattu
+* @bhavneet-sharma
+* @jennifer-john
+* @pavan-mudunuri
+* @trisha-datta

--- a/docs/MAINTAINER_GUIDE.md
+++ b/docs/MAINTAINER_GUIDE.md
@@ -1,0 +1,38 @@
+<!--
+Copyright (c) 2022 Dell Inc., or its subsidiaries. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+-->
+
+# Maintainer guidelines
+
+As a Maintainer of this project you have the responsibility of keeping true to the vision of the project with unprecedented quality. Being part of this group is a privilege that requires dedication and time to attend to the daily activities that are associated with the maintenance of this project.
+
+## Becoming a maintainer
+
+Most Maintainers started as Contributors that have demonstrated their commitment to the success of the project. Contributors wishing to become Maintainers, must demonstrate commitment to the success of the project by contributing code, reviewing others' work, and triaging issues on a regular basis for at least three months.
+
+The contributions alone don't make you a Maintainer. You need to earn the trust of the current Maintainers and other project Contributors, that your decisions and actions are in the best interest of the project.
+
+Periodically, the existing Maintainers curate a list of Contributors who have shown regular activity on the project over the prior months. It is from this list that Maintainer candidates are selected.
+
+After a candidate is selected, the existing Maintainers discuss the candidate over the next 5 business days, provide feedback, and vote. At least 75% of the current Maintainers must vote in the affirmative for a candidate to be moved to the role of Maintainer.
+
+If a candidate is approved, a Maintainer contacts the candidate to invite them to open a pull request that adds the contributor to the MAINTAINERS file. The candidate becomes a Maintainer once the pull request is merged.
+
+## Maintainer policies
+
+* Lead by example
+* Follow the [Code of Conduct](https://github.com/dell/ansible-powerstore/blob/1.7.0/docs/CODE_OF_CONDUCT.md) and the guidelines in the [Contributing](https://github.com/dell/ansible-powerstore/blob/1.7.0/docs/CONTRIBUTING.md) and [Committer](https://github.com/dell/ansible-powerstore/blob/1.7.0/docs/COMMITTER_GUIDE.md) guides
+* Promote a friendly and collaborative environment within our community
+* Be actively engaged in discussions, answering questions, updating defects, and reviewing pull requests
+* Criticize code, not people. Ideally, tell the contributor a better way to do what they need.
+* Clearly mark optional suggestions as such. Best practice, start your comment with *At your option: …*
+
+## Project decision making
+
+All project decisions should contribute to successfully executing on the project roadmap. Project milestones are established for each release.

--- a/docs/Product Guide.md
+++ b/docs/Product Guide.md
@@ -1,5 +1,5 @@
 # Ansible Modules for Dell Technologies PowerStore
-## Product Guide 1.6.0
+## Product Guide 1.7.0
 © 2022 Dell Inc. or its subsidiaries. All rights reserved. Dell, and other trademarks are trademarks of Dell Inc. or its subsidiaries. Other trademarks may be trademarks of their respective owners.
 
 --------------
@@ -249,53 +249,13 @@ Certificate operations for PowerStore Storage System
         <th>Choices</th>
         <th width="80%">Description</th>
     </tr>
-                    <tr>
+                                                            <tr>
             <td colspan=1 > certificate_id</td>
             <td> str  </td>
             <td></td>
             <td></td>
             <td></td>
             <td> <br> Unique identifier of the certificate.  <br> Mandatory only for modify operation. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > service</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td> <ul> <li>Management_HTTP</li>  <li>Replication_HTTP</li>  <li>VASA_HTTP</li>  <li>Import_HTTP</li>  <li>LDAP_HTTP</li>  <li>Syslog_HTTP</li> </ul></td>
-            <td> <br> Type of the service for which the certificate is used.  <br> Mandatory for reset and exchange operation. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > remote_address</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> IPv4 or DNS name of the remote cluster. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > state</td>
-            <td> str  </td>
-            <td> True </td>
-            <td></td>
-            <td> <ul> <li>absent</li>  <li>present</li> </ul></td>
-            <td> <br> Define whether the certificate should exist or not. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > remote_port</td>
-            <td> int  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> The port address of the remote cluster. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > port</td>
-            <td> int  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Port number for the PowerStore array.  <br> If not passed, it will take 443 as default. </td>
         </tr>
                     <tr>
             <td colspan=1 > certificate_type</td>
@@ -306,52 +266,12 @@ Certificate operations for PowerStore Storage System
             <td> <br> Type of the certificate. </td>
         </tr>
                     <tr>
-            <td colspan=1 > is_current</td>
-            <td> bool  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Indicates whether this is the current X509 certificate to be used by the service or this X509 Certificate will be used in the future. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > certificate</td>
+            <td colspan=1 > service</td>
             <td> str  </td>
             <td></td>
             <td></td>
-            <td></td>
-            <td> <br> Concatenated PEM encoded x509_certificate string from end-entity certificate to root certificate. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > remote_password</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> The password of the remote cluster. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > timeout</td>
-            <td> int  </td>
-            <td></td>
-            <td> 120 </td>
-            <td></td>
-            <td> <br> Time after which the connection will get terminated.  <br> It is to be mentioned in seconds. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > user</td>
-            <td> str  </td>
-            <td> True </td>
-            <td></td>
-            <td></td>
-            <td> <br> The username of the PowerStore host. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > array_ip</td>
-            <td> str  </td>
-            <td> True </td>
-            <td></td>
-            <td></td>
-            <td> <br> IP or FQDN of the PowerStore management system. </td>
+            <td> <ul> <li>Management_HTTP</li>  <li>Replication_HTTP</li>  <li>VASA_HTTP</li>  <li>Import_HTTP</li>  <li>LDAP_HTTP</li>  <li>Syslog_HTTP</li> </ul></td>
+            <td> <br> Type of the service for which the certificate is used.  <br> Mandatory for reset and exchange operation. </td>
         </tr>
                     <tr>
             <td colspan=1 > scope</td>
@@ -362,12 +282,20 @@ Certificate operations for PowerStore Storage System
             <td> <br> Defines a subset of certificates belonging to one Service. </td>
         </tr>
                     <tr>
-            <td colspan=1 > verifycert</td>
-            <td> bool  </td>
-            <td> True </td>
+            <td colspan=1 > certificate</td>
+            <td> str  </td>
             <td></td>
-            <td> <ul> <li>True</li>  <li>False</li> </ul></td>
-            <td> <br> Boolean variable to specify whether to validate SSL certificate or not.  <br> True - indicates that the SSL certificate should be verified. Set the environment variable REQUESTS_CA_BUNDLE to the path of the SSL certificate.  <br> False - indicates that the SSL certificate should not be verified. </td>
+            <td></td>
+            <td></td>
+            <td> <br> Concatenated PEM encoded x509_certificate string from end-entity certificate to root certificate. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > remote_address</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> IPv4 or DNS name of the remote cluster. </td>
         </tr>
                     <tr>
             <td colspan=1 > remote_user</td>
@@ -378,6 +306,62 @@ Certificate operations for PowerStore Storage System
             <td> <br> The username of the remote cluster. </td>
         </tr>
                     <tr>
+            <td colspan=1 > remote_password</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> The password of the remote cluster. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > remote_port</td>
+            <td> int  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> The port address of the remote cluster. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > is_current</td>
+            <td> bool  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Indicates whether this is the current X509 certificate to be used by the service or this X509 Certificate will be used in the future. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > state</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td> <ul> <li>absent</li>  <li>present</li> </ul></td>
+            <td> <br> Define whether the certificate should exist or not. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > array_ip</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td></td>
+            <td> <br> IP or FQDN of the PowerStore management system. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > verifycert</td>
+            <td> bool  </td>
+            <td> True </td>
+            <td></td>
+            <td> <ul> <li>True</li>  <li>False</li> </ul></td>
+            <td> <br> Boolean variable to specify whether to validate SSL certificate or not.  <br> True - indicates that the SSL certificate should be verified. Set the environment variable REQUESTS_CA_BUNDLE to the path of the SSL certificate.  <br> False - indicates that the SSL certificate should not be verified. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > user</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td></td>
+            <td> <br> The username of the PowerStore host. </td>
+        </tr>
+                    <tr>
             <td colspan=1 > password</td>
             <td> str  </td>
             <td> True </td>
@@ -385,7 +369,23 @@ Certificate operations for PowerStore Storage System
             <td></td>
             <td> <br> The password of the PowerStore host. </td>
         </tr>
-                                                                                            </table>
+                    <tr>
+            <td colspan=1 > timeout</td>
+            <td> int  </td>
+            <td></td>
+            <td> 120 </td>
+            <td></td>
+            <td> <br> Time after which the connection will get terminated.  <br> It is to be mentioned in seconds. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > port</td>
+            <td> int  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Port number for the PowerStore array.  <br> If not passed, it will take 443 as default. </td>
+        </tr>
+                                                    </table>
 
 ### Notes
 * Idempotency is not supported for adding/importing certificates, exchange of certificates and the reset of certificates.
@@ -460,33 +460,13 @@ Certificate operations for PowerStore Storage System
         <th>Returned</th>
         <th width="100%">Description</th>
     </tr>
-                                    <tr>
-            <td colspan=3 > changed </td>
-            <td>  bool </td>
-            <td> always </td>
-            <td> Whether or not the resource has changed. </td>
-        </tr>
-                    <tr>
+                                                                                            <tr>
             <td colspan=3 > certificate_details </td>
             <td>  complex </td>
             <td> When certificate exists </td>
             <td> Details of the certificate. </td>
         </tr>
                             <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > type_l10n </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Localized message string corresponding to type. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > service </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Type of the service for which the certificate is used. </td>
-            </tr>
-                                <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=2 > id </td>
                 <td> str </td>
@@ -495,17 +475,17 @@ Certificate operations for PowerStore Storage System
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > is_current </td>
+                <td> bool </td>
+                <td>success</td>
+                <td> Whether the certificate can be used now or not. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=2 > is_valid </td>
                 <td> bool </td>
                 <td>success</td>
                 <td> Indicates whether this is a valid X509 certificate. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > service_l10n </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Localized message string corresponding to service. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
@@ -517,66 +497,10 @@ Certificate operations for PowerStore Storage System
                                          <tr>
                     <td class="elbow-placeholder">&nbsp;</td>
                     <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=1 > thumbprint </td>
-                    <td> str </td>
-                    <td>success</td>
-                    <td> CeHash value of the certificate. </td>
-                </tr>
-                                             <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=1 > serial_number </td>
-                    <td> str </td>
-                    <td>success</td>
-                    <td> Certificate serial number. </td>
-                </tr>
-                                             <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=1 > issuer </td>
-                    <td> str </td>
-                    <td>success</td>
-                    <td> Distinguished name of the certificate issuer. </td>
-                </tr>
-                                             <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=1 > signature_algorithm </td>
-                    <td> str </td>
-                    <td>success</td>
-                    <td> Certificate signature algorithm. </td>
-                </tr>
-                                             <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=1 > public_key_algorithm </td>
-                    <td> str </td>
-                    <td>success</td>
-                    <td> Public key algorithm used to generate the key pair. </td>
-                </tr>
-                                             <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=1 > subject </td>
-                    <td> str </td>
-                    <td>success</td>
-                    <td> Certificate subject or so called distinguished name. </td>
-                </tr>
-                                             <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
                     <td colspan=1 > certificate </td>
                     <td> str </td>
                     <td>success</td>
                     <td> Base64 encoded certificate without any line breaks. </td>
-                </tr>
-                                             <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=1 > thumbprint_algorithm_l10n </td>
-                    <td> str </td>
-                    <td>success</td>
-                    <td> Localized message string corresponding to thumbprint_algorithm. </td>
                 </tr>
                                              <tr>
                     <td class="elbow-placeholder">&nbsp;</td>
@@ -589,26 +513,10 @@ Certificate operations for PowerStore Storage System
                                              <tr>
                     <td class="elbow-placeholder">&nbsp;</td>
                     <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=1 > thumbprint_algorithm </td>
+                    <td colspan=1 > issuer </td>
                     <td> str </td>
                     <td>success</td>
-                    <td> The thumbprint algorithm. </td>
-                </tr>
-                                             <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=1 > subject_alternative_names </td>
-                    <td> list </td>
-                    <td>success</td>
-                    <td> Additional DNS names or IP addresses in the x509_certificate. </td>
-                </tr>
-                                             <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=1 > valid_to </td>
-                    <td> str </td>
-                    <td>success</td>
-                    <td> Date and time when the certificate will expire. </td>
+                    <td> Distinguished name of the certificate issuer. </td>
                 </tr>
                                              <tr>
                     <td class="elbow-placeholder">&nbsp;</td>
@@ -621,12 +529,98 @@ Certificate operations for PowerStore Storage System
                                              <tr>
                     <td class="elbow-placeholder">&nbsp;</td>
                     <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=1 > public_key_algorithm </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> Public key algorithm used to generate the key pair. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=1 > serial_number </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> Certificate serial number. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=1 > signature_algorithm </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> Certificate signature algorithm. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=1 > subject </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> Certificate subject or so called distinguished name. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=1 > subject_alternative_names </td>
+                    <td> list </td>
+                    <td>success</td>
+                    <td> Additional DNS names or IP addresses in the x509_certificate. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=1 > thumbprint </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> CeHash value of the certificate. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=1 > thumbprint_algorithm </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> The thumbprint algorithm. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=1 > thumbprint_algorithm_l10n </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> Localized message string corresponding to thumbprint_algorithm. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
                     <td colspan=1 > valid_from </td>
                     <td> str </td>
                     <td>success</td>
                     <td> Date and time when the certificate becomes valid. </td>
                 </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=1 > valid_to </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> Date and time when the certificate will expire. </td>
+                </tr>
                                                             <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > service </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Type of the service for which the certificate is used. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > service_l10n </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Localized message string corresponding to service. </td>
+            </tr>
+                                <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=2 > type </td>
                 <td> str </td>
@@ -635,12 +629,18 @@ Certificate operations for PowerStore Storage System
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > is_current </td>
-                <td> bool </td>
+                <td colspan=2 > type_l10n </td>
+                <td> str </td>
                 <td>success</td>
-                <td> Whether the certificate can be used now or not. </td>
+                <td> Localized message string corresponding to type. </td>
             </tr>
-                                                                                                </table>
+                                        <tr>
+            <td colspan=3 > changed </td>
+            <td>  bool </td>
+            <td> always </td>
+            <td> Whether or not the resource has changed. </td>
+        </tr>
+                    </table>
 
 ### Authors
 * Trisha Datta (@Trisha_Datta) <ansible.team@dell.com>
@@ -648,136 +648,24 @@ Certificate operations for PowerStore Storage System
 --------------------------------
 # Cluster Module
 
-Manage cluster related opeartions on PowerStore
+Manage cluster related operations on PowerStore
 
 ### Synopsis
- Managing cluster on PowerStore storage system includes getting details and modifying cluster configuration parameters.
+ Managing cluster on PowerStore storage system includes creating cluster, validating create cluster attributes, getting details and modifying cluster configuration parameters.
 
 ### Parameters
-                                                                                                                                                                                                                                                                                                                                                                                
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
 <table>
     <tr>
-        <th colspan=1>Parameter</th>
+        <th colspan=3>Parameter</th>
         <th width="20%">Type</th>
         <th>Required</th>
         <th>Default</th>
         <th>Choices</th>
         <th width="80%">Description</th>
     </tr>
-                    <tr>
-            <td colspan=1 > is_ssh_enabled</td>
-            <td> bool  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Whether SSH access is enabled for the cluster.  <br> Either appliance_id or appliance_name is to be passed along with is_ssh_enabled. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > array_ip</td>
-            <td> str  </td>
-            <td> True </td>
-            <td></td>
-            <td></td>
-            <td> <br> IP or FQDN of the PowerStore management system. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > physical_mtu</td>
-            <td> int  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> MTU for ethernet ports in the cluster.  <br> The MTU can be set between 1500 to 9000. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > appliance_name</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Name of the appliance.  <br> Parameters appliance_id and appliance_name are mutually exclusive.  <br> Parameter is_ssh_enabled has to be passed along with appliance_name. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > port</td>
-            <td> int  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Port number for the PowerStore array.  <br> If not passed, it will take 443 as default. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > service_password</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> The password for the service user. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > new_name</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> The new name for the cluster. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > timeout</td>
-            <td> int  </td>
-            <td></td>
-            <td> 120 </td>
-            <td></td>
-            <td> <br> Time after which the connection will get terminated.  <br> It is to be mentioned in seconds. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > appliance_id</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> ID of the appliance.  <br> Parameters appliance_id and appliance_name are mutually exclusive.  <br> Parameter is_ssh_enabled has to be passed along with appliance_id. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > user</td>
-            <td> str  </td>
-            <td> True </td>
-            <td></td>
-            <td></td>
-            <td> <br> The username of the PowerStore host. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > chap_mode</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td> <ul> <li>Disabled</li>  <li>Single</li>  <li>Mutual</li> </ul></td>
-            <td> <br> The mode that describes or sets the iSCSI CHAP mode for the cluster. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > state</td>
-            <td> str  </td>
-            <td> True </td>
-            <td></td>
-            <td> <ul> <li>absent</li>  <li>present</li> </ul></td>
-            <td> <br> Define whether the cluster should exist or not.  <br> Value present indicates that the cluster should exist on the system.  <br> Value absent indicates that the cluster should not exist on the system. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > verifycert</td>
-            <td> bool  </td>
-            <td> True </td>
-            <td></td>
-            <td> <ul> <li>True</li>  <li>False</li> </ul></td>
-            <td> <br> Boolean variable to specify whether to validate SSL certificate or not.  <br> True - indicates that the SSL certificate should be verified. Set the environment variable REQUESTS_CA_BUNDLE to the path of the SSL certificate.  <br> False - indicates that the SSL certificate should not be verified. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > password</td>
-            <td> str  </td>
-            <td> True </td>
-            <td></td>
-            <td></td>
-            <td> <br> The password of the PowerStore host. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > cluster_name</td>
+                                                            <tr>
+            <td colspan=3 > cluster_name</td>
             <td> str  </td>
             <td></td>
             <td></td>
@@ -785,18 +673,494 @@ Manage cluster related opeartions on PowerStore
             <td> <br> The Name of cluster. </td>
         </tr>
                     <tr>
-            <td colspan=1 > cluster_id</td>
+            <td colspan=3 > chap_mode</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td> <ul> <li>Disabled</li>  <li>Single</li>  <li>Mutual</li> </ul></td>
+            <td> <br> The mode that describes or sets the iSCSI CHAP mode for the cluster. </td>
+        </tr>
+                    <tr>
+            <td colspan=3 > cluster_id</td>
             <td> str  </td>
             <td></td>
             <td></td>
             <td></td>
             <td> <br> Id of the cluster. </td>
         </tr>
-                                                                                            </table>
+                    <tr>
+            <td colspan=3 > new_name</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> The new name for the cluster. </td>
+        </tr>
+                    <tr>
+            <td colspan=3 > service_password</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> The password for the service user. </td>
+        </tr>
+                    <tr>
+            <td colspan=3 > appliance_id</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> ID of the appliance.  <br> Parameters appliance_id and appliance_name are mutually exclusive.  <br> Parameter is_ssh_enabled has to be passed along with appliance_id. </td>
+        </tr>
+                    <tr>
+            <td colspan=3 > appliance_name</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Name of the appliance.  <br> Parameters appliance_id and appliance_name are mutually exclusive.  <br> Parameter is_ssh_enabled has to be passed along with appliance_name. </td>
+        </tr>
+                    <tr>
+            <td colspan=3 > is_ssh_enabled</td>
+            <td> bool  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Whether SSH access is enabled for the cluster.  <br> Either appliance_id or appliance_name is to be passed along with is_ssh_enabled. </td>
+        </tr>
+                    <tr>
+            <td colspan=3 > physical_mtu</td>
+            <td> int  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> MTU for ethernet ports in the cluster.  <br> The MTU can be set between 1500 to 9000. </td>
+        </tr>
+                    <tr>
+            <td colspan=3 > ignore_network_warnings</td>
+            <td> bool  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Whether to ignore the network warning about unreachable external network. </td>
+        </tr>
+                    <tr>
+            <td colspan=3 > appliances</td>
+            <td> list   <br> elements: dict </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Appliance configuration setting during cluster creation.  <br> This is mandatory for create cluster operation. </td>
+        </tr>
+                            <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > link_local_address </td>
+                <td> str  </td>
+                <td> True </td>
+                <td></td>
+                <td></td>
+                <td>  <br> The unique IPv4 address of the appliance and is set by zeroconf.  </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > name </td>
+                <td> str  </td>
+                <td></td>
+                <td></td>
+                <td></td>
+                <td>  <br> Name of new appliance.  </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > drive_failure_tolerance_level </td>
+                <td> str  </td>
+                <td></td>
+                <td></td>
+                <td> <ul> <li>Single</li>  <li>Double</li> </ul></td>
+                <td>  <br> Specifies the possible drive failure tolerance levels.  </td>
+            </tr>
+                                        <tr>
+            <td colspan=3 > dns_servers</td>
+            <td> list   <br> elements: str </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> DNS server addresses in IPv4 format. At least one DNS server should be provided.  <br> This is mandatory for create cluster operation. </td>
+        </tr>
+                    <tr>
+            <td colspan=3 > ntp_servers</td>
+            <td> list   <br> elements: str </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> NTP server addresses in IPv4 or hostname format. At least one NTP server should be provided.  <br> This is mandatory for create cluster operation. </td>
+        </tr>
+                    <tr>
+            <td colspan=3 > physical_switches</td>
+            <td> list   <br> elements: dict </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Physical switch setting for a new cluster. </td>
+        </tr>
+                            <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > name </td>
+                <td> str  </td>
+                <td> True </td>
+                <td></td>
+                <td></td>
+                <td>  <br> Name of the physical switch.  </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > purpose </td>
+                <td> str  </td>
+                <td> True </td>
+                <td></td>
+                <td> <ul> <li>Data_and_Management</li>  <li>Management_Only</li> </ul></td>
+                <td>  <br> Specifies the purpose of the physical switch.  </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > connections </td>
+                <td> list   <br> elements: dict </td>
+                <td> True </td>
+                <td></td>
+                <td></td>
+                <td>  <br> specifies the supported connection for the physical switch.  </td>
+            </tr>
+                                         <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=1 > address </td>
+                    <td> str  </td>
+                    <td> True </td>
+                    <td></td>
+                    <td></td>
+                    <td>  <br> Specifies the physical switch address in IPv4 or DNS hostname format.  </td>
+                </tr>
+                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=1 > port </td>
+                    <td> int  </td>
+                    <td></td>
+                    <td></td>
+                    <td></td>
+                    <td>  <br> Specifies the port used for connection to switch.  </td>
+                </tr>
+                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=1 > connect_method </td>
+                    <td> str  </td>
+                    <td> True </td>
+                    <td></td>
+                    <td> <ul> <li>SSH</li>  <li>SNMPv2c</li> </ul></td>
+                    <td>  <br> Specifies the connection method type for the physical Switch.  </td>
+                </tr>
+                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=1 > username </td>
+                    <td> str  </td>
+                    <td></td>
+                    <td></td>
+                    <td></td>
+                    <td>  <br> Specifies username to connect a physical switch for SSH connection method.  </td>
+                </tr>
+                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=1 > ssh_password </td>
+                    <td> str  </td>
+                    <td></td>
+                    <td></td>
+                    <td></td>
+                    <td>  <br> Specifies SSH password to connect a physical switch.  </td>
+                </tr>
+                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=1 > snmp_community_string </td>
+                    <td> str  </td>
+                    <td></td>
+                    <td></td>
+                    <td></td>
+                    <td>  <br> Specifies SNMPv2 community string, if SNMPv2 connect method is selected.  </td>
+                </tr>
+                                                    <tr>
+            <td colspan=3 > networks</td>
+            <td> list   <br> elements: dict </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Configuration of one or more network(s) based on network type.  <br> This is mandatory for create cluster operation. </td>
+        </tr>
+                            <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > type </td>
+                <td> str  </td>
+                <td> True </td>
+                <td></td>
+                <td> <ul> <li>Management</li>  <li>Intra_Cluster_Management</li>  <li>Intra_Cluster_Data</li>  <li>Storage</li>  <li>VMotion</li>  <li>File_Mobility</li> </ul></td>
+                <td>  <br> Specifies the type of the network.  </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > vlan_id </td>
+                <td> int  </td>
+                <td></td>
+                <td></td>
+                <td></td>
+                <td>  <br> The ID of the VLAN.  </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > prefix_length </td>
+                <td> int  </td>
+                <td> True </td>
+                <td></td>
+                <td></td>
+                <td>  <br> Network prefix length.  </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > gateway </td>
+                <td> str  </td>
+                <td></td>
+                <td></td>
+                <td></td>
+                <td>  <br> Network gateway in IPv4 format.  </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > cluster_mgmt_address </td>
+                <td> str  </td>
+                <td></td>
+                <td></td>
+                <td></td>
+                <td>  <br> New cluster management IP address in IPv4 format.  </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > storage_discovery_address </td>
+                <td> str  </td>
+                <td></td>
+                <td></td>
+                <td></td>
+                <td>  <br> New storage discovery IP address in IPv4 format.  <br> This can be specified only when configure the storage network type.  </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > addresses </td>
+                <td> list   <br> elements: str </td>
+                <td> True </td>
+                <td></td>
+                <td></td>
+                <td>  <br> IP addresses in IPv4 format.  </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > purposes </td>
+                <td> list   <br> elements: str </td>
+                <td></td>
+                <td></td>
+                <td> <ul> <li>ISCSI</li>  <li>NVMe_TCP</li>  <li>File_Mobility</li> </ul></td>
+                <td>  <br> Purpose of the network.  <br> Only applicable for storage network.  </td>
+            </tr>
+                                        <tr>
+            <td colspan=3 > vcenters</td>
+            <td> list   <br> elements: dict </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Configure vCenter settings when creating cluster.  <br> Currently, for vcenters parameter API supports only single element.  <br> This is required when creating PowerStore X cluster and optional for PowerStore T. </td>
+        </tr>
+                            <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > address </td>
+                <td> str  </td>
+                <td> True </td>
+                <td></td>
+                <td></td>
+                <td>  <br> IP address of vCenter in IPv4 or hostname format.  </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > username </td>
+                <td> str  </td>
+                <td> True </td>
+                <td></td>
+                <td></td>
+                <td>  <br> User name to login to vCenter.  </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > password </td>
+                <td> str  </td>
+                <td> True </td>
+                <td></td>
+                <td></td>
+                <td>  <br> Password to login to vCenter.  </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > is_verify_server_cert </td>
+                <td> bool  </td>
+                <td> True </td>
+                <td></td>
+                <td></td>
+                <td>  <br> Whether or not the connection will be secured with the vcenter SSL certificate.  </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > data_center_name </td>
+                <td> str  </td>
+                <td></td>
+                <td></td>
+                <td></td>
+                <td>  <br> Name of the data center.  <br> This is used to join an existing datacenter in vcenter.  <br> This should be specified when creating PowerStore X cluster.  <br> Mutually exclusive with data_center_id.  </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > data_center_id </td>
+                <td> str  </td>
+                <td></td>
+                <td></td>
+                <td></td>
+                <td>  <br> The VMWare ID of datacenter.  <br> This is used to join an existing datacenter in vcenter.  <br> This should be specified when creating PowerStore X cluster.  <br> Mutually exclusive with data_center_name.  </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > esx_cluster_name </td>
+                <td> str  </td>
+                <td></td>
+                <td></td>
+                <td></td>
+                <td>  <br> Name of the ESXi cluster.  <br> This should be specified when creating PowerStore X cluster.  </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > vasa_provider_credentials </td>
+                <td> dict  </td>
+                <td> True </td>
+                <td></td>
+                <td></td>
+                <td>  <br> Storage system credentials for vCenter to use for communicating with the storage system using VASA.  </td>
+            </tr>
+                                         <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=1 > username </td>
+                    <td> str  </td>
+                    <td> True </td>
+                    <td></td>
+                    <td></td>
+                    <td>  <br> Username of the local user account which will be used by vSphere to register VASA provider.  </td>
+                </tr>
+                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=1 > password </td>
+                    <td> str  </td>
+                    <td> True </td>
+                    <td></td>
+                    <td></td>
+                    <td>  <br> Password of the local user account which will be used by vSphere to register VASA provider.  </td>
+                </tr>
+                                                    <tr>
+            <td colspan=3 > is_http_redirect_enabled</td>
+            <td> bool  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Whether to redirect the HTTP requests to HTTPS. </td>
+        </tr>
+                    <tr>
+            <td colspan=3 > validate_create</td>
+            <td> bool  </td>
+            <td></td>
+            <td> True </td>
+            <td></td>
+            <td> <br> Whether to perform create cluster validate call. </td>
+        </tr>
+                    <tr>
+            <td colspan=3 > wait_for_completion</td>
+            <td> bool  </td>
+            <td></td>
+            <td> False </td>
+            <td></td>
+            <td> <br> Flag to indicate if the operation should be run synchronously or asynchronously.  <br> True signifies synchronous execution. By default, create cluster operation will run asynchronously. </td>
+        </tr>
+                    <tr>
+            <td colspan=3 > state</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td> <ul> <li>absent</li>  <li>present</li> </ul></td>
+            <td> <br> Define whether the cluster should exist or not.  <br> Value present indicates that the cluster should exist on the system.  <br> Value absent indicates that the cluster should not exist on the system. </td>
+        </tr>
+                    <tr>
+            <td colspan=3 > array_ip</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td></td>
+            <td> <br> IP or FQDN of the PowerStore management system. </td>
+        </tr>
+                    <tr>
+            <td colspan=3 > verifycert</td>
+            <td> bool  </td>
+            <td> True </td>
+            <td></td>
+            <td> <ul> <li>True</li>  <li>False</li> </ul></td>
+            <td> <br> Boolean variable to specify whether to validate SSL certificate or not.  <br> True - indicates that the SSL certificate should be verified. Set the environment variable REQUESTS_CA_BUNDLE to the path of the SSL certificate.  <br> False - indicates that the SSL certificate should not be verified. </td>
+        </tr>
+                    <tr>
+            <td colspan=3 > user</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td></td>
+            <td> <br> The username of the PowerStore host. </td>
+        </tr>
+                    <tr>
+            <td colspan=3 > password</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td></td>
+            <td> <br> The password of the PowerStore host. </td>
+        </tr>
+                    <tr>
+            <td colspan=3 > timeout</td>
+            <td> int  </td>
+            <td></td>
+            <td> 120 </td>
+            <td></td>
+            <td> <br> Time after which the connection will get terminated.  <br> It is to be mentioned in seconds. </td>
+        </tr>
+                    <tr>
+            <td colspan=3 > port</td>
+            <td> int  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Port number for the PowerStore array.  <br> If not passed, it will take 443 as default. </td>
+        </tr>
+                                                    </table>
 
 ### Notes
-* Creation and deletion of cluster is not supported by ansible modules.
+* Deletion of a cluster is not supported by ansible module.
 * The check_mode is not supported.
+* Before performing create operation, the default password for admin user and service user should be changed.
+* For management type network during cluster creation, storage_discovery_address and purposes should not be passed.
+* The vcenters parameter is mandatory for PowerStore X cluster creation.
+* Minimum 3 and 5 addresses are required for management network for PowerStore T and X model respectively.
+* The File_Mobility purpose is supported only in FootHills Prime and above.
+* Parameter is_http_redirect_enabled is supported only in PowerStore FootHills Prime and above.
 * The modules present in this collection named as 'dellemc.powerstore' are built to support the Dell PowerStore storage platform.
 
 ### Examples
@@ -823,10 +1187,105 @@ Manage cluster related opeartions on PowerStore
     chap_mode: "Disabled"
     new_name: "new_RT-D1320"
     state: "present"
+
+- name: Validate create cluster
+  dellemc.powerstore.cluster:
+    array_ip: "{{array_ip}}"
+    verifycert: "{{verifycert}}"
+    user: "{{user}}"
+    password: "{{password}}"
+    cluster_name: "RT-D1320"
+    ignore_network_warnings: True
+    appliances:
+      - link_local_address: "1.2.x.x"
+        name: "Ansible_cluster"
+        derive_failure_tolerance_level: "Double"
+    dns_servers:
+      - "1.1.x.x"
+    ntp_servers:
+      - "1.3.x.x"
+    networks:
+      - type: "Management"
+        vlan_id: 0
+        prefix_length: 24
+        gateway: "1.x.x.x"
+        cluster_mgmt_address: "1.x.x.x"
+        addresses:
+          - "2.x.x.x"
+          - "3.x.x.x"
+      - type: "Storage"
+        vlan_id: 0
+        prefix_length: 42
+        gateway: "1.x.x.x"
+        storage_discovery_address: "1.x.x.x"
+        addresses:
+          - "2.x.x.x"
+          - "3.x.x.x"
+        purpose:
+          - "ISCSI"
+    is_http_redirect_enabled: True
+    validate_create: True
+    state: "present"
+
+- name: Create cluster
+  dellemc.powerstore.cluster:
+    array_ip: "{{array_ip}}"
+    verifycert: "{{verifycert}}"
+    user: "{{user}}"
+    password: "{{password}}"
+    cluster_name: "RT-D1320"
+    ignore_network_warnings: True
+    appliances:
+      - link_local_address: "1.2.x.x"
+        name: "Ansible_cluster"
+        derive_failure_tolerance_level: "Double"
+    dns_servers:
+      - "1.1.x.x"
+    ntp_servers:
+      - "1.3.x.x"
+    physical_switch:
+      - name: "Ansible_switch"
+        purpose: "Management_Only"
+        connections:
+          - address: "1.x.x.x"
+            port: 20
+            connect_method: "SSH"
+            username: "user"
+            ssh_password: "password"
+    networks:
+      - type: "Management"
+        vlan_id: 0
+        prefix_length: 24
+        gateway: "1.x.x.x"
+        cluster_mgmt_address: "1.x.x.x"
+        addresses:
+          - "2.x.x.x"
+          - "3.x.x.x"
+      - type: "Storage"
+        vlan_id: 0
+        prefix_length: 42
+        gateway: "1.x.x.x"
+        storage_discovery_address: "1.x.x.x"
+        addresses:
+          - "2.x.x.x"
+          - "3.x.x.x"
+        purpose:
+          - "ISCSI"
+    vcenters:
+      - address: "1.x.x.x"
+        username: "user"
+        password: "password"
+        is_verify_server_cert: True
+        vasa_provider_credentials:
+          username: "user"
+          password: "password"
+    is_http_redirect_enabled: True
+    wait_for_completion: False
+    state: "present"
 ```
 
 ### Return Values
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                
 <table>
     <tr>
         <th colspan=5>Key</th>
@@ -834,7 +1293,7 @@ Manage cluster related opeartions on PowerStore
         <th>Returned</th>
         <th width="100%">Description</th>
     </tr>
-                                    <tr>
+                                                                                            <tr>
             <td colspan=5 > changed </td>
             <td>  bool </td>
             <td> always </td>
@@ -848,13 +1307,6 @@ Manage cluster related opeartions on PowerStore
         </tr>
                             <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=4 > id </td>
-                <td> str </td>
-                <td>success</td>
-                <td> The ID of the cluster. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=4 > appliance_count </td>
                 <td> int </td>
                 <td>success</td>
@@ -862,17 +1314,61 @@ Manage cluster related opeartions on PowerStore
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=4 > appliance_details </td>
+                <td> complex </td>
+                <td>success</td>
+                <td> Name and Id of the appliance for which is_ssh_enabled parameter is used. </td>
+            </tr>
+                                         <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=3 > id </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> Id of the appliance. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=3 > name </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> Name of the appliance. </td>
+                </tr>
+                                                            <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=4 > compatibility_level </td>
+                <td> int </td>
+                <td>success</td>
+                <td> The behavioral version of the software version API, It is used to ensure the compatibility across potentially different software versions. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=4 > global_id </td>
+                <td> str </td>
+                <td>success</td>
+                <td> The global unique identifier of the cluster. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=4 > id </td>
+                <td> str </td>
+                <td>success</td>
+                <td> The ID of the cluster. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=4 > is_encryption_enabled </td>
+                <td> bool </td>
+                <td>success</td>
+                <td> Whether or not Data at Rest Encryption is enabled on the cluster. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=4 > is_ssh_enabled </td>
                 <td> bool </td>
                 <td>success</td>
                 <td> Whether or not the ssh is enabled. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=4 > physical_mtu </td>
-                <td> int </td>
-                <td>success</td>
-                <td> MTU for the cluster. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
@@ -890,29 +1386,6 @@ Manage cluster related opeartions on PowerStore
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=4 > appliance_details </td>
-                <td> complex </td>
-                <td>success</td>
-                <td> Name and Id of the appliance for which is_ssh_enabled parameter is used. </td>
-            </tr>
-                                         <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=3 > name </td>
-                    <td> str </td>
-                    <td>success</td>
-                    <td> Name of the appliance. </td>
-                </tr>
-                                             <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=3 > id </td>
-                    <td> str </td>
-                    <td>success</td>
-                    <td> Id of the appliance. </td>
-                </tr>
-                                                            <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=4 > name </td>
                 <td> str </td>
                 <td>success</td>
@@ -920,86 +1393,19 @@ Manage cluster related opeartions on PowerStore
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=4 > storage_discovery_address </td>
-                <td> str </td>
-                <td>success</td>
-                <td> The floating storage discovery IP address for the cluster in IPv4 or IPv6 format. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=4 > compatibility_level </td>
+                <td colspan=4 > physical_mtu </td>
                 <td> int </td>
                 <td>success</td>
-                <td> The behavioral version of the software version API, It is used to ensure the compatibility across potentially different software versions. </td>
+                <td> MTU for the cluster. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=4 > system_time </td>
+                <td colspan=4 > primary_appliance_id </td>
                 <td> str </td>
                 <td>success</td>
-                <td> Current clock time for the system. System time and all the system reported times are in UTC (GMT+0:00) format. </td>
+                <td> The unique identifier of the appliance acting as primary. This parameter was added in version 2.0.0.0. </td>
             </tr>
                                 <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=4 > state </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Possible cluster states. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=4 > is_encryption_enabled </td>
-                <td> bool </td>
-                <td>success</td>
-                <td> Whether or not Data at Rest Encryption is enabled on the cluster. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=4 > global_id </td>
-                <td> str </td>
-                <td>success</td>
-                <td> The global unique identifier of the cluster. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=4 > service_user_details </td>
-                <td> complex </td>
-                <td>success</td>
-                <td> Details of the service user for which the password can be updated. </td>
-            </tr>
-                                         <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=3 > name </td>
-                    <td> str </td>
-                    <td>success</td>
-                    <td> Name of the service user. </td>
-                </tr>
-                                             <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=3 > is_built_in </td>
-                    <td> bool </td>
-                    <td>success</td>
-                    <td> Whether the service user is built in or not. </td>
-                </tr>
-                                             <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=3 > id </td>
-                    <td> str </td>
-                    <td>success</td>
-                    <td> Id of the service user. </td>
-                </tr>
-                                             <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=3 > is_default_password </td>
-                    <td> bool </td>
-                    <td>success</td>
-                    <td> Whether the service user has default password or not. </td>
-                </tr>
-                                                            <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=4 > service_config_details </td>
                 <td> complex </td>
@@ -1032,15 +1438,82 @@ Manage cluster related opeartions on PowerStore
                 </tr>
                                                             <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=4 > primary_appliance_id </td>
+                <td colspan=4 > service_user_details </td>
+                <td> complex </td>
+                <td>success</td>
+                <td> Details of the service user for which the password can be updated. </td>
+            </tr>
+                                         <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=3 > id </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> Id of the service user. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=3 > is_built_in </td>
+                    <td> bool </td>
+                    <td>success</td>
+                    <td> Whether the service user is built in or not. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=3 > is_default_password </td>
+                    <td> bool </td>
+                    <td>success</td>
+                    <td> Whether the service user has default password or not. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=3 > name </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> Name of the service user. </td>
+                </tr>
+                                                            <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=4 > state </td>
                 <td> str </td>
                 <td>success</td>
-                <td> The unique identifier of the appliance acting as primary. This parameter was added in version 2.0.0.0. </td>
+                <td> Possible cluster states. </td>
             </tr>
-                                                                                                </table>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=4 > storage_discovery_address </td>
+                <td> str </td>
+                <td>success</td>
+                <td> The floating storage discovery IP address for the cluster in IPv4 or IPv6 format. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=4 > system_time </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Current clock time for the system. System time and all the system reported times are in UTC (GMT+0:00) format. </td>
+            </tr>
+                                        <tr>
+            <td colspan=5 > job_details </td>
+            <td>  complex </td>
+            <td> When asynchronous task is performed. </td>
+            <td> The job details. </td>
+        </tr>
+                            <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=4 > id </td>
+                <td> str </td>
+                <td>success</td>
+                <td> The ID of the job. </td>
+            </tr>
+                                        </table>
 
 ### Authors
 * P Srinivas Rao (@srinivas-rao5) <ansible.team@dell.com>
+* Bhavneet Sharma (@sharmb5) <ansible.team@dell.com>
 
 --------------------------------
 # DNS Module
@@ -1061,29 +1534,29 @@ DNS operations on a PowerStore storage system
         <th>Choices</th>
         <th width="80%">Description</th>
     </tr>
-                    <tr>
-            <td colspan=1 > timeout</td>
-            <td> int  </td>
-            <td></td>
-            <td> 120 </td>
-            <td></td>
-            <td> <br> Time after which the connection will get terminated.  <br> It is to be mentioned in seconds. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > user</td>
+                                                            <tr>
+            <td colspan=1 > dns_id</td>
             <td> str  </td>
             <td> True </td>
             <td></td>
             <td></td>
-            <td> <br> The username of the PowerStore host. </td>
+            <td> <br> Unique identifier of the DNS instance. </td>
         </tr>
                     <tr>
-            <td colspan=1 > password</td>
+            <td colspan=1 > dns_addresses</td>
+            <td> list   <br> elements: str </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> DNS server addresses in IPv4 format. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > dns_address_state</td>
             <td> str  </td>
-            <td> True </td>
             <td></td>
             <td></td>
-            <td> <br> The password of the PowerStore host. </td>
+            <td> <ul> <li>present-in-dns</li>  <li>absent-in-dns</li> </ul></td>
+            <td> <br> State of the addresses mentioned in dns_addresses. </td>
         </tr>
                     <tr>
             <td colspan=1 > state</td>
@@ -1110,6 +1583,30 @@ DNS operations on a PowerStore storage system
             <td> <br> Boolean variable to specify whether to validate SSL certificate or not.  <br> True - indicates that the SSL certificate should be verified. Set the environment variable REQUESTS_CA_BUNDLE to the path of the SSL certificate.  <br> False - indicates that the SSL certificate should not be verified. </td>
         </tr>
                     <tr>
+            <td colspan=1 > user</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td></td>
+            <td> <br> The username of the PowerStore host. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > password</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td></td>
+            <td> <br> The password of the PowerStore host. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > timeout</td>
+            <td> int  </td>
+            <td></td>
+            <td> 120 </td>
+            <td></td>
+            <td> <br> Time after which the connection will get terminated.  <br> It is to be mentioned in seconds. </td>
+        </tr>
+                    <tr>
             <td colspan=1 > port</td>
             <td> int  </td>
             <td></td>
@@ -1117,31 +1614,7 @@ DNS operations on a PowerStore storage system
             <td></td>
             <td> <br> Port number for the PowerStore array.  <br> If not passed, it will take 443 as default. </td>
         </tr>
-                    <tr>
-            <td colspan=1 > dns_id</td>
-            <td> str  </td>
-            <td> True </td>
-            <td></td>
-            <td></td>
-            <td> <br> Unique identifier of the DNS instance. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > dns_addresses</td>
-            <td> list   <br> elements: str </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> DNS server addresses in IPv4 format. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > dns_address_state</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td> <ul> <li>present-in-dns</li>  <li>absent-in-dns</li> </ul></td>
-            <td> <br> State of the addresses mentioned in dns_addresses. </td>
-        </tr>
-                                                                                            </table>
+                                                    </table>
 
 ### Notes
 * Minimum 1 and maximum 3 addresses can be associated to a DNS instance.
@@ -1196,7 +1669,13 @@ DNS operations on a PowerStore storage system
         <th>Returned</th>
         <th width="100%">Description</th>
     </tr>
-                                    <tr>
+                                                                                            <tr>
+            <td colspan=2 > changed </td>
+            <td>  bool </td>
+            <td> always </td>
+            <td> Whether or not the resource has changed. </td>
+        </tr>
+                    <tr>
             <td colspan=2 > dns_details </td>
             <td>  complex </td>
             <td> When DNS exists. </td>
@@ -1216,13 +1695,7 @@ DNS operations on a PowerStore storage system
                 <td>success</td>
                 <td> Unique identifier of DNS instance. </td>
             </tr>
-                                        <tr>
-            <td colspan=2 > changed </td>
-            <td>  bool </td>
-            <td> always </td>
-            <td> Whether or not the resource has changed. </td>
-        </tr>
-                                                                            </table>
+                                        </table>
 
 ### Authors
 * Trisha Datta (@Trisha_Datta) <ansible.team@dell.com>
@@ -1239,7 +1712,7 @@ Destination Email operations on a PowerStore storage system
  This Module supports delete/remove a specific destination email address. Send a test mail to a specific destination email address.
 
 ### Parameters
-                                                                                                                                                                                                                                                                                                                                        
+                                                                                                                                                                                                                                                                                                                                                                                                                                
 <table>
     <tr>
         <th colspan=2>Parameter</th>
@@ -1249,29 +1722,13 @@ Destination Email operations on a PowerStore storage system
         <th>Choices</th>
         <th width="80%">Description</th>
     </tr>
-                    <tr>
-            <td colspan=2 > state</td>
-            <td> str  </td>
-            <td> True </td>
-            <td></td>
-            <td> <ul> <li>present</li>  <li>absent</li> </ul></td>
-            <td> <br> The state of the destination email address after the task is performed.  <br> For Delete operation only, it should be set to "absent".  <br> For all Create, Modify, Test or Get details operations it should be set to "present". </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > new_address</td>
+                                                            <tr>
+            <td colspan=2 > email_id</td>
             <td> str  </td>
             <td></td>
             <td></td>
             <td></td>
-            <td> <br> New email address to receive notifications. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > port</td>
-            <td> int  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Port number for the PowerStore array.  <br> If not passed, it will take 443 as default. </td>
+            <td> <br> Unique identifier of the destination email address.  <br> Mutually exclusive with email_address. </td>
         </tr>
                     <tr>
             <td colspan=2 > email_address</td>
@@ -1282,36 +1739,12 @@ Destination Email operations on a PowerStore storage system
             <td> <br> Email address to receive notifications.  <br> Mutually exclusive with email_id. </td>
         </tr>
                     <tr>
-            <td colspan=2 > timeout</td>
-            <td> int  </td>
-            <td></td>
-            <td> 120 </td>
-            <td></td>
-            <td> <br> Time after which the connection will get terminated.  <br> It is to be mentioned in seconds. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > email_id</td>
+            <td colspan=2 > new_address</td>
             <td> str  </td>
             <td></td>
             <td></td>
             <td></td>
-            <td> <br> Unique identifier of the destination email address.  <br> Mutually exclusive with email_address. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > user</td>
-            <td> str  </td>
-            <td> True </td>
-            <td></td>
-            <td></td>
-            <td> <br> The username of the PowerStore host. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > array_ip</td>
-            <td> str  </td>
-            <td> True </td>
-            <td></td>
-            <td></td>
-            <td> <br> IP or FQDN of the PowerStore management system. </td>
+            <td> <br> New email address to receive notifications. </td>
         </tr>
                     <tr>
             <td colspan=2 > send_test_email</td>
@@ -1338,25 +1771,7 @@ Destination Email operations on a PowerStore storage system
                 <td></td>
                 <td>  <br> Whether to send notifications for critical alerts.  </td>
             </tr>
-                    <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > minor </td>
-                <td> bool  </td>
-                <td> False </td>
-                <td></td>
-                <td></td>
-                <td>  <br> Whether to send notifications for minor alerts.  </td>
-            </tr>
-                    <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > info </td>
-                <td> bool  </td>
-                <td> False </td>
-                <td></td>
-                <td></td>
-                <td>  <br> Whether to send notifications for informational alerts.  </td>
-            </tr>
-                    <tr>
+                                <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=1 > major </td>
                 <td> bool  </td>
@@ -1365,13 +1780,55 @@ Destination Email operations on a PowerStore storage system
                 <td></td>
                 <td>  <br> Whether to send notifications for major alerts.  </td>
             </tr>
-                            <tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > minor </td>
+                <td> bool  </td>
+                <td> False </td>
+                <td></td>
+                <td></td>
+                <td>  <br> Whether to send notifications for minor alerts.  </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > info </td>
+                <td> bool  </td>
+                <td> False </td>
+                <td></td>
+                <td></td>
+                <td>  <br> Whether to send notifications for informational alerts.  </td>
+            </tr>
+                                        <tr>
+            <td colspan=2 > state</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td> <ul> <li>present</li>  <li>absent</li> </ul></td>
+            <td> <br> The state of the destination email address after the task is performed.  <br> For Delete operation only, it should be set to "absent".  <br> For all Create, Modify, Test or Get details operations it should be set to "present". </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > array_ip</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td></td>
+            <td> <br> IP or FQDN of the PowerStore management system. </td>
+        </tr>
+                    <tr>
             <td colspan=2 > verifycert</td>
             <td> bool  </td>
             <td> True </td>
             <td></td>
             <td> <ul> <li>True</li>  <li>False</li> </ul></td>
             <td> <br> Boolean variable to specify whether to validate SSL certificate or not.  <br> True - indicates that the SSL certificate should be verified. Set the environment variable REQUESTS_CA_BUNDLE to the path of the SSL certificate.  <br> False - indicates that the SSL certificate should not be verified. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > user</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td></td>
+            <td> <br> The username of the PowerStore host. </td>
         </tr>
                     <tr>
             <td colspan=2 > password</td>
@@ -1381,7 +1838,23 @@ Destination Email operations on a PowerStore storage system
             <td></td>
             <td> <br> The password of the PowerStore host. </td>
         </tr>
-                                                                                            </table>
+                    <tr>
+            <td colspan=2 > timeout</td>
+            <td> int  </td>
+            <td></td>
+            <td> 120 </td>
+            <td></td>
+            <td> <br> Time after which the connection will get terminated.  <br> It is to be mentioned in seconds. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > port</td>
+            <td> int  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Port number for the PowerStore array.  <br> If not passed, it will take 443 as default. </td>
+        </tr>
+                                                    </table>
 
 ### Notes
 * Idempotency is not supported for Test operation of Email module.
@@ -1463,7 +1936,7 @@ Destination Email operations on a PowerStore storage system
         <th>Returned</th>
         <th width="100%">Description</th>
     </tr>
-                                    <tr>
+                                                                                            <tr>
             <td colspan=3 > changed </td>
             <td>  bool </td>
             <td> always </td>
@@ -1476,6 +1949,20 @@ Destination Email operations on a PowerStore storage system
             <td> Details of the destination email address. </td>
         </tr>
                             <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > email_address </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Email address to receive notifications. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > id </td>
+                <td> str </td>
+                <td>success</td>
+                <td> The system generated ID of the destination email instance. </td>
+            </tr>
+                                <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=2 > notify </td>
                 <td> complex </td>
@@ -1493,14 +1980,6 @@ Destination Email operations on a PowerStore storage system
                                              <tr>
                     <td class="elbow-placeholder">&nbsp;</td>
                     <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=1 > minor </td>
-                    <td> bool </td>
-                    <td>success</td>
-                    <td> Whether to send notifications for minor alerts. </td>
-                </tr>
-                                             <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
                     <td colspan=1 > info </td>
                     <td> bool </td>
                     <td>success</td>
@@ -1514,21 +1993,15 @@ Destination Email operations on a PowerStore storage system
                     <td>success</td>
                     <td> Whether to send notifications for major alerts. </td>
                 </tr>
-                                                            <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > email_address </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Email address to receive notifications. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > id </td>
-                <td> str </td>
-                <td>success</td>
-                <td> The system generated ID of the destination email instance. </td>
-            </tr>
-                                                                                                </table>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=1 > minor </td>
+                    <td> bool </td>
+                    <td>success</td>
+                    <td> Whether to send notifications for minor alerts. </td>
+                </tr>
+                                                                    </table>
 
 ### Authors
 * Trisha Datta (@Trisha_Datta) <ansible.team@dell.com>
@@ -1542,7 +2015,7 @@ Filesystem operations for PowerStore Storage system
  Supports the provisioning operations on a filesystem such as create, modify, delete and get the details of a filesystem.
 
 ### Parameters
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        
 <table>
     <tr>
         <th colspan=2>Parameter</th>
@@ -1552,13 +2025,37 @@ Filesystem operations for PowerStore Storage system
         <th>Choices</th>
         <th width="80%">Description</th>
     </tr>
+                                                            <tr>
+            <td colspan=2 > filesystem_name</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Name of the file system. Mutually exclusive with filesystem_id. Mandatory only for create operation. </td>
+        </tr>
                     <tr>
-            <td colspan=2 > timeout</td>
-            <td> int  </td>
+            <td colspan=2 > filesystem_id</td>
+            <td> str  </td>
             <td></td>
-            <td> 120 </td>
             <td></td>
-            <td> <br> Time after which the connection will get terminated.  <br> It is to be mentioned in seconds. </td>
+            <td></td>
+            <td> <br> Unique id of the file system. Mutually exclusive with filesystem_name. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > description</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Description of the file system. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > nas_server</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Name or ID of the NAS Server on which the file system is created. Mandatory parameter whenever filesystem_name is provided, since filesystem names are unique only within a NAS server. </td>
         </tr>
                     <tr>
             <td colspan=2 > size</td>
@@ -1569,90 +2066,20 @@ Filesystem operations for PowerStore Storage system
             <td> <br> Size that the file system presents to the host or end user. Mandatory only for create operation. </td>
         </tr>
                     <tr>
-            <td colspan=2 > smb_properties</td>
-            <td> dict  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Advance settings for SMB. It contains below optional candidate variables. </td>
-        </tr>
-                            <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > smb_notify_on_change_dir_depth </td>
-                <td> int  </td>
-                <td> False </td>
-                <td></td>
-                <td></td>
-                <td>  <br> Integer variable , determines the lowest directory level to which the enabled notifications apply. minimum value is 1.  </td>
-            </tr>
-                    <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > is_smb_notify_on_write_enabled </td>
-                <td> bool  </td>
-                <td> False </td>
-                <td></td>
-                <td></td>
-                <td>  <br> Indicates whether file write notifications are enabled on the file system.  </td>
-            </tr>
-                    <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > is_smb_op_locks_enabled </td>
-                <td> bool  </td>
-                <td> False </td>
-                <td></td>
-                <td></td>
-                <td>  <br> Indicates whether opportunistic file locking is enabled on the file system.  </td>
-            </tr>
-                    <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > is_smb_notify_on_access_enabled </td>
-                <td> bool  </td>
-                <td> False </td>
-                <td></td>
-                <td></td>
-                <td>  <br> Indicates whether file access notifications are enabled on the file system.  </td>
-            </tr>
-                    <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > is_smb_sync_writes_enabled </td>
-                <td> bool  </td>
-                <td> False </td>
-                <td></td>
-                <td></td>
-                <td>  <br> Indicates whether the synchronous writes option is enabled on the file system.  </td>
-            </tr>
-                    <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > is_smb_no_notify_enabled </td>
-                <td> bool  </td>
-                <td> False </td>
-                <td></td>
-                <td></td>
-                <td>  <br> Indicates whether notifications of changes to directory file structure are enabled.  </td>
-            </tr>
-                            <tr>
-            <td colspan=2 > filesystem_id</td>
+            <td colspan=2 > cap_unit</td>
             <td> str  </td>
             <td></td>
             <td></td>
-            <td></td>
-            <td> <br> Unique id of the file system. Mutually exclusive with filesystem_name. </td>
+            <td> <ul> <li>GB</li>  <li>TB</li> </ul></td>
+            <td> <br> Capacity unit for the size.  <br> It defaults to 'GB', if not specified. </td>
         </tr>
                     <tr>
-            <td colspan=2 > port</td>
-            <td> int  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Port number for the PowerStore array.  <br> If not passed, it will take 443 as default. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > protection_policy</td>
+            <td colspan=2 > access_policy</td>
             <td> str  </td>
             <td></td>
             <td></td>
-            <td></td>
-            <td> <br> Name or ID of the protection policy applied to the file system.  <br> Specifying "" (empty string) removes the existing protection policy from file system. </td>
+            <td> <ul> <li>NATIVE</li>  <li>UNIX</li>  <li>WINDOWS</li> </ul></td>
+            <td> <br> File system security access policies. </td>
         </tr>
                     <tr>
             <td colspan=2 > locking_policy</td>
@@ -1671,84 +2098,74 @@ Filesystem operations for PowerStore Storage system
             <td> <br> File system folder rename policies for the file system with multi-protocol access enabled.  <br> ALL_ALLOWED - All protocols are allowed to rename directories without any restrictions.  <br> SMB_FORBIDDEN - A directory rename from the SMB protocol will be denied if at least one file is opened in the directory or in one of its child directories.  <br> All_FORBIDDEN - Any directory rename request will be denied regardless of the protocol used, if at least one file is opened in the directory or in one of its child directories. </td>
         </tr>
                     <tr>
-            <td colspan=2 > nas_server</td>
+            <td colspan=2 > smb_properties</td>
+            <td> dict  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Advance settings for SMB. It contains below optional candidate variables. </td>
+        </tr>
+                            <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > is_smb_sync_writes_enabled </td>
+                <td> bool  </td>
+                <td> False </td>
+                <td></td>
+                <td></td>
+                <td>  <br> Indicates whether the synchronous writes option is enabled on the file system.  </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > is_smb_no_notify_enabled </td>
+                <td> bool  </td>
+                <td> False </td>
+                <td></td>
+                <td></td>
+                <td>  <br> Indicates whether notifications of changes to directory file structure are enabled.  </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > is_smb_op_locks_enabled </td>
+                <td> bool  </td>
+                <td> False </td>
+                <td></td>
+                <td></td>
+                <td>  <br> Indicates whether opportunistic file locking is enabled on the file system.  </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > is_smb_notify_on_access_enabled </td>
+                <td> bool  </td>
+                <td> False </td>
+                <td></td>
+                <td></td>
+                <td>  <br> Indicates whether file access notifications are enabled on the file system.  </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > is_smb_notify_on_write_enabled </td>
+                <td> bool  </td>
+                <td> False </td>
+                <td></td>
+                <td></td>
+                <td>  <br> Indicates whether file write notifications are enabled on the file system.  </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > smb_notify_on_change_dir_depth </td>
+                <td> int  </td>
+                <td> False </td>
+                <td></td>
+                <td></td>
+                <td>  <br> Integer variable , determines the lowest directory level to which the enabled notifications apply. minimum value is 1.  </td>
+            </tr>
+                                        <tr>
+            <td colspan=2 > protection_policy</td>
             <td> str  </td>
             <td></td>
             <td></td>
             <td></td>
-            <td> <br> Name or ID of the NAS Server on which the file system is created. Mandatory parameter whenever filesystem_name is provided, since filesystem names are unique only within a NAS server. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > user</td>
-            <td> str  </td>
-            <td> True </td>
-            <td></td>
-            <td></td>
-            <td> <br> The username of the PowerStore host. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > cap_unit</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td> <ul> <li>GB</li>  <li>TB</li> </ul></td>
-            <td> <br> Capacity unit for the size.  <br> It defaults to 'GB', if not specified. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > state</td>
-            <td> str  </td>
-            <td> True </td>
-            <td></td>
-            <td> <ul> <li>absent</li>  <li>present</li> </ul></td>
-            <td> <br> Define whether the filesystem should exist or not. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > verifycert</td>
-            <td> bool  </td>
-            <td> True </td>
-            <td></td>
-            <td> <ul> <li>True</li>  <li>False</li> </ul></td>
-            <td> <br> Boolean variable to specify whether to validate SSL certificate or not.  <br> True - indicates that the SSL certificate should be verified. Set the environment variable REQUESTS_CA_BUNDLE to the path of the SSL certificate.  <br> False - indicates that the SSL certificate should not be verified. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > access_policy</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td> <ul> <li>NATIVE</li>  <li>UNIX</li>  <li>WINDOWS</li> </ul></td>
-            <td> <br> File system security access policies. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > filesystem_name</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Name of the file system. Mutually exclusive with filesystem_id. Mandatory only for create operation. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > password</td>
-            <td> str  </td>
-            <td> True </td>
-            <td></td>
-            <td></td>
-            <td> <br> The password of the PowerStore host. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > description</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Description of the file system. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > array_ip</td>
-            <td> str  </td>
-            <td> True </td>
-            <td></td>
-            <td></td>
-            <td> <br> IP or FQDN of the PowerStore management system. </td>
+            <td> <br> Name or ID of the protection policy applied to the file system.  <br> Specifying "" (empty string) removes the existing protection policy from file system. </td>
         </tr>
                     <tr>
             <td colspan=2 > quota_defaults</td>
@@ -1760,15 +2177,6 @@ Filesystem operations for PowerStore Storage system
         </tr>
                             <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > default_hard_limit </td>
-                <td> int  </td>
-                <td> False </td>
-                <td></td>
-                <td></td>
-                <td>  <br> Default hard limit of user quotas and tree quotas.  </td>
-            </tr>
-                    <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=1 > grace_period </td>
                 <td> int  </td>
                 <td> False </td>
@@ -1776,16 +2184,7 @@ Filesystem operations for PowerStore Storage system
                 <td></td>
                 <td>  <br> Grace period of soft limit.  </td>
             </tr>
-                    <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > default_soft_limit </td>
-                <td> int  </td>
-                <td> False </td>
-                <td></td>
-                <td></td>
-                <td>  <br> Default soft limit of user quotas and tree quotas.  </td>
-            </tr>
-                    <tr>
+                                <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=1 > grace_period_unit </td>
                 <td> str  </td>
@@ -1794,7 +2193,25 @@ Filesystem operations for PowerStore Storage system
                 <td> <ul> <li>days</li>  <li>weeks</li>  <li>months</li> </ul></td>
                 <td>  <br> Unit of the grace period of soft limit.  </td>
             </tr>
-                    <tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > default_hard_limit </td>
+                <td> int  </td>
+                <td> False </td>
+                <td></td>
+                <td></td>
+                <td>  <br> Default hard limit of user quotas and tree quotas.  </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > default_soft_limit </td>
+                <td> int  </td>
+                <td> False </td>
+                <td></td>
+                <td></td>
+                <td>  <br> Default soft limit of user quotas and tree quotas.  </td>
+            </tr>
+                                <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=1 > cap_unit </td>
                 <td> str  </td>
@@ -1803,7 +2220,63 @@ Filesystem operations for PowerStore Storage system
                 <td> <ul> <li>GB</li>  <li>TB</li> </ul></td>
                 <td>  <br> Capacity unit for default hard & soft limit.  </td>
             </tr>
-                                                                                                    </table>
+                                        <tr>
+            <td colspan=2 > state</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td> <ul> <li>absent</li>  <li>present</li> </ul></td>
+            <td> <br> Define whether the filesystem should exist or not. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > array_ip</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td></td>
+            <td> <br> IP or FQDN of the PowerStore management system. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > verifycert</td>
+            <td> bool  </td>
+            <td> True </td>
+            <td></td>
+            <td> <ul> <li>True</li>  <li>False</li> </ul></td>
+            <td> <br> Boolean variable to specify whether to validate SSL certificate or not.  <br> True - indicates that the SSL certificate should be verified. Set the environment variable REQUESTS_CA_BUNDLE to the path of the SSL certificate.  <br> False - indicates that the SSL certificate should not be verified. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > user</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td></td>
+            <td> <br> The username of the PowerStore host. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > password</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td></td>
+            <td> <br> The password of the PowerStore host. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > timeout</td>
+            <td> int  </td>
+            <td></td>
+            <td> 120 </td>
+            <td></td>
+            <td> <br> Time after which the connection will get terminated.  <br> It is to be mentioned in seconds. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > port</td>
+            <td> int  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Port number for the PowerStore array.  <br> If not passed, it will take 443 as default. </td>
+        </tr>
+                                                    </table>
 
 ### Notes
 * It is recommended to remove the protection policy before deleting the filesystem.
@@ -1883,7 +2356,7 @@ Filesystem operations for PowerStore Storage system
         <th>Returned</th>
         <th width="100%">Description</th>
     </tr>
-                                    <tr>
+                                                                                            <tr>
             <td colspan=2 > changed </td>
             <td>  bool </td>
             <td> always </td>
@@ -1897,17 +2370,17 @@ Filesystem operations for PowerStore Storage system
         </tr>
                             <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > size_total </td>
-                <td> int </td>
+                <td colspan=1 > access_policy </td>
+                <td> str </td>
                 <td>success</td>
-                <td> Total size of the filesystem in bytes. </td>
+                <td> Access policy about the filesystem. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > name </td>
-                <td> str </td>
+                <td colspan=1 > default_hard_limit </td>
+                <td> int </td>
                 <td>success</td>
-                <td> Name of the filesystem. </td>
+                <td> Default hard limit period for a filesystem quota in byte. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
@@ -1918,17 +2391,31 @@ Filesystem operations for PowerStore Storage system
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > snapshots </td>
-                <td> list </td>
+                <td colspan=1 > description </td>
+                <td> str </td>
                 <td>success</td>
-                <td> Id and name of the snapshots of a filesystem. </td>
+                <td> The description about the filesystem. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > used_size_with_unit </td>
+                <td colspan=1 > grace_period </td>
+                <td> int </td>
+                <td>success</td>
+                <td> Default grace period for a filesystem quota in second. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > id </td>
                 <td> str </td>
                 <td>success</td>
-                <td> Used size of the filesystem with appropriate unit. </td>
+                <td> The system generated ID given to the filesystem. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > is_smb_no_notify_enabled </td>
+                <td> bool </td>
+                <td>success</td>
+                <td> Whether smb notify policy is enabled for a filesystem. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
@@ -1946,17 +2433,17 @@ Filesystem operations for PowerStore Storage system
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > grace_period </td>
-                <td> int </td>
+                <td colspan=1 > locking_policy </td>
+                <td> str </td>
                 <td>success</td>
-                <td> Default grace period for a filesystem quota in second. </td>
+                <td> Locking policy about the filesystem. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > total_size_with_unit </td>
+                <td colspan=1 > name </td>
                 <td> str </td>
                 <td>success</td>
-                <td> Total size of the filesystem with appropriate unit. </td>
+                <td> Name of the filesystem. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
@@ -1967,10 +2454,17 @@ Filesystem operations for PowerStore Storage system
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > id </td>
-                <td> str </td>
+                <td colspan=1 > protection_policy </td>
+                <td> dict </td>
                 <td>success</td>
-                <td> The system generated ID given to the filesystem. </td>
+                <td> Id and name of the protection policy associated with the filesystem. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > size_total </td>
+                <td> int </td>
+                <td>success</td>
+                <td> Total size of the filesystem in bytes. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
@@ -1981,47 +2475,26 @@ Filesystem operations for PowerStore Storage system
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > protection_policy </td>
-                <td> dict </td>
+                <td colspan=1 > snapshots </td>
+                <td> list </td>
                 <td>success</td>
-                <td> Id and name of the protection policy associated with the filesystem. </td>
+                <td> Id and name of the snapshots of a filesystem. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > access_policy </td>
+                <td colspan=1 > total_size_with_unit </td>
                 <td> str </td>
                 <td>success</td>
-                <td> Access policy about the filesystem. </td>
+                <td> Total size of the filesystem with appropriate unit. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > locking_policy </td>
+                <td colspan=1 > used_size_with_unit </td>
                 <td> str </td>
                 <td>success</td>
-                <td> Locking policy about the filesystem. </td>
+                <td> Used size of the filesystem with appropriate unit. </td>
             </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > is_smb_no_notify_enabled </td>
-                <td> bool </td>
-                <td>success</td>
-                <td> Whether smb notify policy is enabled for a filesystem. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > description </td>
-                <td> str </td>
-                <td>success</td>
-                <td> The description about the filesystem. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > default_hard_limit </td>
-                <td> int </td>
-                <td>success</td>
-                <td> Default hard limit period for a filesystem quota in byte. </td>
-            </tr>
-                                                                                                </table>
+                                        </table>
 
 ### Authors
 * Arindam Datta (@dattaarindam) <ansible.team@dell.com>
@@ -2045,45 +2518,13 @@ Manage Filesystem Snapshots for PowerStore
         <th>Choices</th>
         <th width="80%">Description</th>
     </tr>
-                    <tr>
+                                                            <tr>
             <td colspan=1 > snapshot_name</td>
             <td> str  </td>
             <td></td>
             <td></td>
             <td></td>
             <td> <br> The name of the filesystem snapshot.  <br> Mandatory for create operation.  <br> Specify either snapshot name or ID (but not both) for any operation. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > filesystem</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> The ID/Name of the filesystem for which snapshot will be taken.  <br> If filesystem name is specified, then nas_server is required to uniquely identify the filesystem.  <br> Mandatory for create operation. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > desired_retention</td>
-            <td> int  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> The retention value for the Snapshot.  <br> If the desired_retention/expiration_timestamp is not mentioned during creation, snapshot will be created with unlimited retention.  <br> Maximum supported desired retention is 31 days. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > port</td>
-            <td> int  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Port number for the PowerStore array.  <br> If not passed, it will take 443 as default. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > retention_unit</td>
-            <td> str  </td>
-            <td></td>
-            <td> hours </td>
-            <td> <ul> <li>hours</li>  <li>days</li> </ul></td>
-            <td> <br> The unit for retention. </td>
         </tr>
                     <tr>
             <td colspan=1 > snapshot_id</td>
@@ -2094,36 +2535,12 @@ Manage Filesystem Snapshots for PowerStore
             <td> <br> The ID of the Snapshot. </td>
         </tr>
                     <tr>
-            <td colspan=1 > expiration_timestamp</td>
+            <td colspan=1 > filesystem</td>
             <td> str  </td>
             <td></td>
             <td></td>
             <td></td>
-            <td> <br> The expiration timestamp of the snapshot. This should be provided in UTC format, e.g 2020-07-24T10:54:54Z.  <br> To remove the expiration timestamp, specify it as an empty string. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > description</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> The description for the filesystem snapshot. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > timeout</td>
-            <td> int  </td>
-            <td></td>
-            <td> 120 </td>
-            <td></td>
-            <td> <br> Time after which the connection will get terminated.  <br> It is to be mentioned in seconds. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > array_ip</td>
-            <td> str  </td>
-            <td> True </td>
-            <td></td>
-            <td></td>
-            <td> <br> IP or FQDN of the PowerStore management system. </td>
+            <td> <br> The ID/Name of the filesystem for which snapshot will be taken.  <br> If filesystem name is specified, then nas_server is required to uniquely identify the filesystem.  <br> Mandatory for create operation. </td>
         </tr>
                     <tr>
             <td colspan=1 > nas_server</td>
@@ -2134,12 +2551,44 @@ Manage Filesystem Snapshots for PowerStore
             <td> <br> The NAS server, this could be the name or ID of the NAS server. </td>
         </tr>
                     <tr>
-            <td colspan=1 > user</td>
+            <td colspan=1 > description</td>
             <td> str  </td>
-            <td> True </td>
             <td></td>
             <td></td>
-            <td> <br> The username of the PowerStore host. </td>
+            <td></td>
+            <td> <br> The description for the filesystem snapshot. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > desired_retention</td>
+            <td> int  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> The retention value for the Snapshot.  <br> If the desired_retention/expiration_timestamp is not mentioned during creation, snapshot will be created with unlimited retention.  <br> Maximum supported desired retention is 31 days. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > retention_unit</td>
+            <td> str  </td>
+            <td></td>
+            <td> hours </td>
+            <td> <ul> <li>hours</li>  <li>days</li> </ul></td>
+            <td> <br> The unit for retention. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > expiration_timestamp</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> The expiration timestamp of the snapshot. This should be provided in UTC format, e.g 2020-07-24T10:54:54Z.  <br> To remove the expiration timestamp, specify it as an empty string. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > access_type</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td> <ul> <li>SNAPSHOT</li>  <li>PROTOCOL</li> </ul></td>
+            <td> <br> Specifies whether the snapshot directory or protocol access is granted to the filesystem snapshot.  <br> For create operation, if access_type is not specified, snapshot will be created with 'SNAPSHOT' access type. </td>
         </tr>
                     <tr>
             <td colspan=1 > state</td>
@@ -2150,12 +2599,28 @@ Manage Filesystem Snapshots for PowerStore
             <td> <br> Define whether the filesystem snapshot should exist or not. </td>
         </tr>
                     <tr>
+            <td colspan=1 > array_ip</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td></td>
+            <td> <br> IP or FQDN of the PowerStore management system. </td>
+        </tr>
+                    <tr>
             <td colspan=1 > verifycert</td>
             <td> bool  </td>
             <td> True </td>
             <td></td>
             <td> <ul> <li>True</li>  <li>False</li> </ul></td>
             <td> <br> Boolean variable to specify whether to validate SSL certificate or not.  <br> True - indicates that the SSL certificate should be verified. Set the environment variable REQUESTS_CA_BUNDLE to the path of the SSL certificate.  <br> False - indicates that the SSL certificate should not be verified. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > user</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td></td>
+            <td> <br> The username of the PowerStore host. </td>
         </tr>
                     <tr>
             <td colspan=1 > password</td>
@@ -2166,14 +2631,22 @@ Manage Filesystem Snapshots for PowerStore
             <td> <br> The password of the PowerStore host. </td>
         </tr>
                     <tr>
-            <td colspan=1 > access_type</td>
-            <td> str  </td>
+            <td colspan=1 > timeout</td>
+            <td> int  </td>
             <td></td>
+            <td> 120 </td>
             <td></td>
-            <td> <ul> <li>SNAPSHOT</li>  <li>PROTOCOL</li> </ul></td>
-            <td> <br> Specifies whether the snapshot directory or protocol access is granted to the filesystem snapshot.  <br> For create operation, if access_type is not specified, snapshot will be created with 'SNAPSHOT' access type. </td>
+            <td> <br> Time after which the connection will get terminated.  <br> It is to be mentioned in seconds. </td>
         </tr>
-                                                                                            </table>
+                    <tr>
+            <td colspan=1 > port</td>
+            <td> int  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Port number for the PowerStore array.  <br> If not passed, it will take 443 as default. </td>
+        </tr>
+                                                    </table>
 
 ### Notes
 * The check_mode is not supported.
@@ -2234,23 +2707,23 @@ Manage Filesystem Snapshots for PowerStore
         <th>Returned</th>
         <th width="100%">Description</th>
     </tr>
-                                    <tr>
-            <td colspan=3 > delete_fs_snap </td>
+                                                                                            <tr>
+            <td colspan=3 > changed </td>
             <td>  bool </td>
             <td> always </td>
-            <td> Whether or not the resource has deleted. </td>
-        </tr>
-                    <tr>
-            <td colspan=3 > modify_fs_snap </td>
-            <td>  bool </td>
-            <td> always </td>
-            <td> Whether or not the resource has modified. </td>
+            <td> Whether or not the resource has changed. </td>
         </tr>
                     <tr>
             <td colspan=3 > create_fs_snap </td>
             <td>  bool </td>
             <td> always </td>
             <td> Whether or not the resource has created. </td>
+        </tr>
+                    <tr>
+            <td colspan=3 > delete_fs_snap </td>
+            <td>  bool </td>
+            <td> always </td>
+            <td> Whether or not the resource has deleted. </td>
         </tr>
                     <tr>
             <td colspan=3 > filesystem_snap_details </td>
@@ -2260,10 +2733,10 @@ Manage Filesystem Snapshots for PowerStore
         </tr>
                             <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > name </td>
+                <td colspan=2 > access_type </td>
                 <td> str </td>
                 <td>success</td>
-                <td> The name of the snapshot. </td>
+                <td> Displays the type of access allowed to the snapshot. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
@@ -2274,24 +2747,10 @@ Manage Filesystem Snapshots for PowerStore
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > id </td>
+                <td colspan=2 > description </td>
                 <td> str </td>
                 <td>success</td>
-                <td> Unique identifier of the filesystem snapshot instance. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > parent_id </td>
-                <td> str </td>
-                <td>success</td>
-                <td> ID of the filesystem on which snapshot is taken. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > access_type </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Displays the type of access allowed to the snapshot. </td>
+                <td> Description of the filesystem snapshot. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
@@ -2302,10 +2761,17 @@ Manage Filesystem Snapshots for PowerStore
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > parent_name </td>
+                <td colspan=2 > id </td>
                 <td> str </td>
                 <td>success</td>
-                <td> Name of the filesystem on which snapshot is taken. </td>
+                <td> Unique identifier of the filesystem snapshot instance. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > name </td>
+                <td> str </td>
+                <td>success</td>
+                <td> The name of the snapshot. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
@@ -2317,33 +2783,40 @@ Manage Filesystem Snapshots for PowerStore
                                          <tr>
                     <td class="elbow-placeholder">&nbsp;</td>
                     <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=1 > name </td>
-                    <td> str </td>
-                    <td>success</td>
-                    <td> Name of the NAS server </td>
-                </tr>
-                                             <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
                     <td colspan=1 > id </td>
                     <td> str </td>
                     <td>success</td>
                     <td> ID of the NAS server. </td>
                 </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=1 > name </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> Name of the NAS server </td>
+                </tr>
                                                             <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > description </td>
+                <td colspan=2 > parent_id </td>
                 <td> str </td>
                 <td>success</td>
-                <td> Description of the filesystem snapshot. </td>
+                <td> ID of the filesystem on which snapshot is taken. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > parent_name </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Name of the filesystem on which snapshot is taken. </td>
             </tr>
                                         <tr>
-            <td colspan=3 > changed </td>
+            <td colspan=3 > modify_fs_snap </td>
             <td>  bool </td>
             <td> always </td>
-            <td> Whether or not the resource has changed. </td>
+            <td> Whether or not the resource has modified. </td>
         </tr>
-                                                                            </table>
+                    </table>
 
 ### Authors
 * Akash Shendge (@shenda1) <ansible.team@dell.com>
@@ -2357,7 +2830,7 @@ Manage host on PowerStore storage system
  Managing host on PowerStore storage system includes create host with a set of initiators, add/remove initiators from host, rename host and delete host.
 
 ### Parameters
-                                                                                                                                                                                                                                                                                                                                                                                
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                
 <table>
     <tr>
         <th colspan=2>Parameter</th>
@@ -2367,29 +2840,13 @@ Manage host on PowerStore storage system
         <th>Choices</th>
         <th width="80%">Description</th>
     </tr>
-                    <tr>
-            <td colspan=2 > array_ip</td>
-            <td> str  </td>
-            <td> True </td>
-            <td></td>
-            <td></td>
-            <td> <br> IP or FQDN of the PowerStore management system. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > initiator_state</td>
+                                                            <tr>
+            <td colspan=2 > host_name</td>
             <td> str  </td>
             <td></td>
             <td></td>
-            <td> <ul> <li>present-in-host</li>  <li>absent-in-host</li> </ul></td>
-            <td> <br> Define whether the initiators should be present or absent in host.  <br> Value present-in-host - indicates that the initiators should exist on host.  <br> Value absent-in-host - indicates that the initiators should not exist on host.  <br> Required when creating a host with initiators or adding/removing initiators to/from existing host. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > port</td>
-            <td> int  </td>
             <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Port number for the PowerStore array.  <br> If not passed, it will take 443 as default. </td>
+            <td> <br> The host name. This value must contain 128 or fewer printable Unicode characters.  <br> Creation of an empty host is not allowed.  <br> Required when creating a host.  <br> Use either host_id or host_name for modify and delete tasks. </td>
         </tr>
                     <tr>
             <td colspan=2 > host_id</td>
@@ -2400,28 +2857,12 @@ Manage host on PowerStore storage system
             <td> <br> The 36 character long host id automatically generated when a host is created.  <br> Use either host_id or host_name for modify and delete tasks.  <br> The host_id cannot be used while creating host, as it is generated by the array after creation of host. </td>
         </tr>
                     <tr>
-            <td colspan=2 > new_name</td>
+            <td colspan=2 > os_type</td>
             <td> str  </td>
             <td></td>
             <td></td>
-            <td></td>
-            <td> <br> The new name of host for renaming function. This value must contain 128 or fewer printable Unicode characters.  <br> Cannot be specified when creating a host. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > timeout</td>
-            <td> int  </td>
-            <td></td>
-            <td> 120 </td>
-            <td></td>
-            <td> <br> Time after which the connection will get terminated.  <br> It is to be mentioned in seconds. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > user</td>
-            <td> str  </td>
-            <td> True </td>
-            <td></td>
-            <td></td>
-            <td> <br> The username of the PowerStore host. </td>
+            <td> <ul> <li>Windows</li>  <li>Linux</li>  <li>ESXi</li>  <li>AIX</li>  <li>HP-UX</li>  <li>Solaris</li> </ul></td>
+            <td> <br> Operating system of the host.  <br> Required when creating a host.  <br> OS type cannot be modified for a given host. </td>
         </tr>
                     <tr>
             <td colspan=2 > initiators</td>
@@ -2430,14 +2871,6 @@ Manage host on PowerStore storage system
             <td></td>
             <td></td>
             <td> <br> List of Initiator WWN or IQN or NQN to be added or removed from the host.  <br> Subordinate initiators in a host can only be of one type, either FC or iSCSI.  <br> Required when creating a host.  <br> It is mutually exclusive with detailed_initiators. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > verifycert</td>
-            <td> bool  </td>
-            <td> True </td>
-            <td></td>
-            <td> <ul> <li>True</li>  <li>False</li> </ul></td>
-            <td> <br> Boolean variable to specify whether to validate SSL certificate or not.  <br> True - indicates that the SSL certificate should be verified. Set the environment variable REQUESTS_CA_BUNDLE to the path of the SSL certificate.  <br> False - indicates that the SSL certificate should not be verified. </td>
         </tr>
                     <tr>
             <td colspan=2 > detailed_initiators</td>
@@ -2449,32 +2882,14 @@ Manage host on PowerStore storage system
         </tr>
                             <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > chap_mutual_username </td>
+                <td colspan=1 > port_name </td>
                 <td> str  </td>
+                <td> True </td>
                 <td></td>
                 <td></td>
-                <td></td>
-                <td>  <br> Username for mutual CHAP authentication.  <br> CHAP username is required when the cluster CHAP mode is mutual authentication.  <br> Minimum length is 1 and maximum length is 64 characters.  </td>
+                <td>  <br> Name of port type.  <br> The port_name is mandatory key.  </td>
             </tr>
-                    <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > chap_single_username </td>
-                <td> str  </td>
-                <td></td>
-                <td></td>
-                <td></td>
-                <td>  <br> Username for single CHAP authentication.  <br> CHAP username is required when the cluster CHAP mode is mutual authentication.  <br> Minimum length is 1 and maximum length is 64 characters.  </td>
-            </tr>
-                    <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > chap_mutual_password </td>
-                <td> str  </td>
-                <td></td>
-                <td></td>
-                <td></td>
-                <td>  <br> Password for mutual CHAP authentication.  <br> CHAP password is required when the cluster CHAP mode is mutual authentication.  <br> Minimum length is 12 and maximum length is 64 characters.  </td>
-            </tr>
-                    <tr>
+                                <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=1 > port_type </td>
                 <td> str  </td>
@@ -2483,16 +2898,16 @@ Manage host on PowerStore storage system
                 <td> <ul> <li>iSCSI</li>  <li>FC</li>  <li>NVMe</li> </ul></td>
                 <td>  <br> Protocol type of the host initiator.  </td>
             </tr>
-                    <tr>
+                                <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > port_name </td>
+                <td colspan=1 > chap_single_username </td>
                 <td> str  </td>
-                <td> True </td>
                 <td></td>
                 <td></td>
-                <td>  <br> Name of port type.  <br> The port_name is mandatory key.  </td>
+                <td></td>
+                <td>  <br> Username for single CHAP authentication.  <br> CHAP username is required when the cluster CHAP mode is mutual authentication.  <br> Minimum length is 1 and maximum length is 64 characters.  </td>
             </tr>
-                    <tr>
+                                <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=1 > chap_single_password </td>
                 <td> str  </td>
@@ -2501,13 +2916,71 @@ Manage host on PowerStore storage system
                 <td></td>
                 <td>  <br> Password for single CHAP authentication.  <br> CHAP password is required when the cluster CHAP mode is mutual authentication.  <br> Minimum length is 12 and maximum length is 64 characters.  </td>
             </tr>
-                            <tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > chap_mutual_username </td>
+                <td> str  </td>
+                <td></td>
+                <td></td>
+                <td></td>
+                <td>  <br> Username for mutual CHAP authentication.  <br> CHAP username is required when the cluster CHAP mode is mutual authentication.  <br> Minimum length is 1 and maximum length is 64 characters.  </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > chap_mutual_password </td>
+                <td> str  </td>
+                <td></td>
+                <td></td>
+                <td></td>
+                <td>  <br> Password for mutual CHAP authentication.  <br> CHAP password is required when the cluster CHAP mode is mutual authentication.  <br> Minimum length is 12 and maximum length is 64 characters.  </td>
+            </tr>
+                                        <tr>
             <td colspan=2 > state</td>
             <td> str  </td>
             <td> True </td>
             <td></td>
             <td> <ul> <li>absent</li>  <li>present</li> </ul></td>
             <td> <br> Define whether the host should exist or not.  <br> Value present - indicates that the host should exist in system.  <br> Value absent - indicates that the host should not exist in system. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > initiator_state</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td> <ul> <li>present-in-host</li>  <li>absent-in-host</li> </ul></td>
+            <td> <br> Define whether the initiators should be present or absent in host.  <br> Value present-in-host - indicates that the initiators should exist on host.  <br> Value absent-in-host - indicates that the initiators should not exist on host.  <br> Required when creating a host with initiators or adding/removing initiators to/from existing host. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > new_name</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> The new name of host for renaming function. This value must contain 128 or fewer printable Unicode characters.  <br> Cannot be specified when creating a host. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > array_ip</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td></td>
+            <td> <br> IP or FQDN of the PowerStore management system. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > verifycert</td>
+            <td> bool  </td>
+            <td> True </td>
+            <td></td>
+            <td> <ul> <li>True</li>  <li>False</li> </ul></td>
+            <td> <br> Boolean variable to specify whether to validate SSL certificate or not.  <br> True - indicates that the SSL certificate should be verified. Set the environment variable REQUESTS_CA_BUNDLE to the path of the SSL certificate.  <br> False - indicates that the SSL certificate should not be verified. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > user</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td></td>
+            <td> <br> The username of the PowerStore host. </td>
         </tr>
                     <tr>
             <td colspan=2 > password</td>
@@ -2518,22 +2991,22 @@ Manage host on PowerStore storage system
             <td> <br> The password of the PowerStore host. </td>
         </tr>
                     <tr>
-            <td colspan=2 > os_type</td>
-            <td> str  </td>
+            <td colspan=2 > timeout</td>
+            <td> int  </td>
             <td></td>
+            <td> 120 </td>
             <td></td>
-            <td> <ul> <li>Windows</li>  <li>Linux</li>  <li>ESXi</li>  <li>AIX</li>  <li>HP-UX</li>  <li>Solaris</li> </ul></td>
-            <td> <br> Operating system of the host.  <br> Required when creating a host.  <br> OS type cannot be modified for a given host. </td>
+            <td> <br> Time after which the connection will get terminated.  <br> It is to be mentioned in seconds. </td>
         </tr>
                     <tr>
-            <td colspan=2 > host_name</td>
-            <td> str  </td>
+            <td colspan=2 > port</td>
+            <td> int  </td>
             <td></td>
             <td></td>
             <td></td>
-            <td> <br> The host name. This value must contain 128 or fewer printable Unicode characters.  <br> Creation of an empty host is not allowed.  <br> Required when creating a host.  <br> Use either host_id or host_name for modify and delete tasks. </td>
+            <td> <br> Port number for the PowerStore array.  <br> If not passed, it will take 443 as default. </td>
         </tr>
-                                                                                            </table>
+                                                    </table>
 
 ### Notes
 * Only completely and correctly configured iSCSI initiators can be associated with a host.
@@ -2698,7 +3171,13 @@ Manage host on PowerStore storage system
         <th>Returned</th>
         <th width="100%">Description</th>
     </tr>
-                                    <tr>
+                                                                                            <tr>
+            <td colspan=6 > changed </td>
+            <td>  bool </td>
+            <td> always </td>
+            <td> Whether or not the resource has changed. </td>
+        </tr>
+                    <tr>
             <td colspan=6 > host_details </td>
             <td>  complex </td>
             <td> When host exists </td>
@@ -2706,24 +3185,17 @@ Manage host on PowerStore storage system
         </tr>
                             <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=5 > name </td>
+                <td colspan=5 > description </td>
                 <td> str </td>
                 <td>success</td>
-                <td> Name of the host. </td>
+                <td> Description about the host. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=5 > id </td>
+                <td colspan=5 > host_group_id </td>
                 <td> str </td>
                 <td>success</td>
-                <td> The system generated ID given to the host. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=5 > os_type </td>
-                <td> str </td>
-                <td>success</td>
-                <td> The os type of the host. </td>
+                <td> The host group ID of host. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
@@ -2733,6 +3205,14 @@ Manage host on PowerStore storage system
                 <td> The initiator details of this host. </td>
             </tr>
                                          <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=4 > active_sessions </td>
+                    <td> list </td>
+                    <td>success</td>
+                    <td> List of active login sessions between an initiator and a target port. </td>
+                </tr>
+                                             <tr>
                     <td class="elbow-placeholder">&nbsp;</td>
                     <td class="elbow-placeholder">&nbsp;</td>
                     <td colspan=4 > chap_mutual_username </td>
@@ -2751,47 +3231,25 @@ Manage host on PowerStore storage system
                                              <tr>
                     <td class="elbow-placeholder">&nbsp;</td>
                     <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=4 > port_type </td>
-                    <td> str </td>
-                    <td>success</td>
-                    <td> The type of the port. </td>
-                </tr>
-                                             <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=4 > active_sessions </td>
-                    <td> list </td>
-                    <td>success</td>
-                    <td> List of active login sessions between an initiator and a target port. </td>
-                </tr>
-                                             <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
                     <td colspan=4 > port_name </td>
                     <td> str </td>
                     <td>success</td>
                     <td> Name of the port. </td>
                 </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=4 > port_type </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> The type of the port. </td>
+                </tr>
                                                             <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=5 > host_group_id </td>
+                <td colspan=5 > id </td>
                 <td> str </td>
                 <td>success</td>
-                <td> The host group ID of host. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=5 > type </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Type of the host. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=5 > description </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Description about the host. </td>
+                <td> The system generated ID given to the host. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
@@ -2801,6 +3259,32 @@ Manage host on PowerStore storage system
                 <td> This is the inverse of the resource type host_volume_mapping association. </td>
             </tr>
                                          <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=4 > host_group </td>
+                    <td> dict </td>
+                    <td>success</td>
+                    <td> Details about a host group to which host is mapped. </td>
+                </tr>
+                                                    <tr>
+                        <td class="elbow-placeholder">&nbsp;</td>
+                        <td class="elbow-placeholder">&nbsp;</td>
+                        <td class="elbow-placeholder">&nbsp;</td>
+                        <td colspan=3 > id </td>
+                        <td> str </td>
+                        <td>success</td>
+                        <td> ID of the host group. </td>
+                    </tr>
+                                    <tr>
+                        <td class="elbow-placeholder">&nbsp;</td>
+                        <td class="elbow-placeholder">&nbsp;</td>
+                        <td class="elbow-placeholder">&nbsp;</td>
+                        <td colspan=3 > name </td>
+                        <td> str </td>
+                        <td>success</td>
+                        <td> Name of the host group. </td>
+                    </tr>
+                                                             <tr>
                     <td class="elbow-placeholder">&nbsp;</td>
                     <td class="elbow-placeholder">&nbsp;</td>
                     <td colspan=4 > id </td>
@@ -2819,32 +3303,6 @@ Manage host on PowerStore storage system
                                              <tr>
                     <td class="elbow-placeholder">&nbsp;</td>
                     <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=4 > host_group </td>
-                    <td> dict </td>
-                    <td>success</td>
-                    <td> Details about a host group to which host is mapped. </td>
-                </tr>
-                                                    <tr>
-                        <td class="elbow-placeholder">&nbsp;</td>
-                        <td class="elbow-placeholder">&nbsp;</td>
-                        <td class="elbow-placeholder">&nbsp;</td>
-                        <td colspan=3 > name </td>
-                        <td> str </td>
-                        <td>success</td>
-                        <td> Name of the host group. </td>
-                    </tr>
-                                    <tr>
-                        <td class="elbow-placeholder">&nbsp;</td>
-                        <td class="elbow-placeholder">&nbsp;</td>
-                        <td class="elbow-placeholder">&nbsp;</td>
-                        <td colspan=3 > id </td>
-                        <td> str </td>
-                        <td>success</td>
-                        <td> ID of the host group. </td>
-                    </tr>
-                                                             <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
                     <td colspan=4 > volume </td>
                     <td> dict </td>
                     <td>success</td>
@@ -2854,27 +3312,42 @@ Manage host on PowerStore storage system
                         <td class="elbow-placeholder">&nbsp;</td>
                         <td class="elbow-placeholder">&nbsp;</td>
                         <td class="elbow-placeholder">&nbsp;</td>
-                        <td colspan=3 > name </td>
-                        <td> str </td>
-                        <td>success</td>
-                        <td> Name of the volume. </td>
-                    </tr>
-                                    <tr>
-                        <td class="elbow-placeholder">&nbsp;</td>
-                        <td class="elbow-placeholder">&nbsp;</td>
-                        <td class="elbow-placeholder">&nbsp;</td>
                         <td colspan=3 > id </td>
                         <td> str </td>
                         <td>success</td>
                         <td> ID of the volume. </td>
                     </tr>
-                                                                                    <tr>
-            <td colspan=6 > changed </td>
-            <td>  bool </td>
-            <td> always </td>
-            <td> Whether or not the resource has changed. </td>
-        </tr>
-                                                                            </table>
+                                    <tr>
+                        <td class="elbow-placeholder">&nbsp;</td>
+                        <td class="elbow-placeholder">&nbsp;</td>
+                        <td class="elbow-placeholder">&nbsp;</td>
+                        <td colspan=3 > name </td>
+                        <td> str </td>
+                        <td>success</td>
+                        <td> Name of the volume. </td>
+                    </tr>
+                                                                            <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=5 > name </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Name of the host. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=5 > os_type </td>
+                <td> str </td>
+                <td>success</td>
+                <td> The os type of the host. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=5 > type </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Type of the host. </td>
+            </tr>
+                                        </table>
 
 ### Authors
 * Manisha Agrawal (@agrawm3) <ansible.team@dell.com>
@@ -2899,29 +3372,13 @@ Manage host group on PowerStore Storage System
         <th>Choices</th>
         <th width="80%">Description</th>
     </tr>
-                    <tr>
-            <td colspan=1 > host_state</td>
+                                                            <tr>
+            <td colspan=1 > hostgroup_name</td>
             <td> str  </td>
             <td></td>
             <td></td>
-            <td> <ul> <li>present-in-group</li>  <li>absent-in-group</li> </ul></td>
-            <td> <br> Define whether the hosts should be present or absent in host group.  <br> Value present-in-group - indicates that the hosts should exist on the host group.  <br> Value absent-in-group - indicates that the hosts should not exist on the host group.  <br> Required when creating a host group with hosts or adding/removing hosts from existing host group. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > state</td>
-            <td> str  </td>
-            <td> True </td>
             <td></td>
-            <td> <ul> <li>absent</li>  <li>present</li> </ul></td>
-            <td> <br> Define whether the host group should exist or not.  <br> Value present - indicates that the host group should exist on the system.  <br> Value absent - indicates that the host group should not exist on the system.  <br> Deletion of a host group results in deletion of the containing hosts as well. Remove hosts from the host group first to retain them. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > port</td>
-            <td> int  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Port number for the PowerStore array.  <br> If not passed, it will take 443 as default. </td>
+            <td> <br> The host group name. This value must contain 128 or fewer printable Unicode characters.  <br> Creation of an empty host group is not allowed.  <br> Required when creating a host group.  <br> Use either hostgroup_id or hostgroup_name for modify and delete tasks. </td>
         </tr>
                     <tr>
             <td colspan=1 > hostgroup_id</td>
@@ -2932,36 +3389,36 @@ Manage host group on PowerStore Storage System
             <td> <br> The 36-character long host group id, automatically generated when a host group is created.  <br> Use either hostgroup_id or hostgroup_name for modify and delete tasks.  <br> The hostgroup_id cannot be used while creating host group, as it is generated by the array after creation of host group. </td>
         </tr>
                     <tr>
-            <td colspan=1 > new_name</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> The new name for host group renaming function. This value must contain 128 or fewer printable Unicode characters. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > timeout</td>
-            <td> int  </td>
-            <td></td>
-            <td> 120 </td>
-            <td></td>
-            <td> <br> Time after which the connection will get terminated.  <br> It is to be mentioned in seconds. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > user</td>
-            <td> str  </td>
-            <td> True </td>
-            <td></td>
-            <td></td>
-            <td> <br> The username of the PowerStore host. </td>
-        </tr>
-                    <tr>
             <td colspan=1 > hosts</td>
             <td> list   <br> elements: str </td>
             <td></td>
             <td></td>
             <td></td>
             <td> <br> List of hosts to be added or removed from the host group.  <br> Subordinate hosts in a host group can only be of one type, either FC or iSCSI.  <br> Required when creating a host group.  <br> To represent host, both name or ID can be used interchangeably. The module will detect both. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > state</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td> <ul> <li>absent</li>  <li>present</li> </ul></td>
+            <td> <br> Define whether the host group should exist or not.  <br> Value present - indicates that the host group should exist on the system.  <br> Value absent - indicates that the host group should not exist on the system.  <br> Deletion of a host group results in deletion of the containing hosts as well. Remove hosts from the host group first to retain them. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > host_state</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td> <ul> <li>present-in-group</li>  <li>absent-in-group</li> </ul></td>
+            <td> <br> Define whether the hosts should be present or absent in host group.  <br> Value present-in-group - indicates that the hosts should exist on the host group.  <br> Value absent-in-group - indicates that the hosts should not exist on the host group.  <br> Required when creating a host group with hosts or adding/removing hosts from existing host group. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > new_name</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> The new name for host group renaming function. This value must contain 128 or fewer printable Unicode characters. </td>
         </tr>
                     <tr>
             <td colspan=1 > array_ip</td>
@@ -2972,20 +3429,20 @@ Manage host group on PowerStore Storage System
             <td> <br> IP or FQDN of the PowerStore management system. </td>
         </tr>
                     <tr>
-            <td colspan=1 > hostgroup_name</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> The host group name. This value must contain 128 or fewer printable Unicode characters.  <br> Creation of an empty host group is not allowed.  <br> Required when creating a host group.  <br> Use either hostgroup_id or hostgroup_name for modify and delete tasks. </td>
-        </tr>
-                    <tr>
             <td colspan=1 > verifycert</td>
             <td> bool  </td>
             <td> True </td>
             <td></td>
             <td> <ul> <li>True</li>  <li>False</li> </ul></td>
             <td> <br> Boolean variable to specify whether to validate SSL certificate or not.  <br> True - indicates that the SSL certificate should be verified. Set the environment variable REQUESTS_CA_BUNDLE to the path of the SSL certificate.  <br> False - indicates that the SSL certificate should not be verified. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > user</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td></td>
+            <td> <br> The username of the PowerStore host. </td>
         </tr>
                     <tr>
             <td colspan=1 > password</td>
@@ -2995,7 +3452,23 @@ Manage host group on PowerStore Storage System
             <td></td>
             <td> <br> The password of the PowerStore host. </td>
         </tr>
-                                                                                            </table>
+                    <tr>
+            <td colspan=1 > timeout</td>
+            <td> int  </td>
+            <td></td>
+            <td> 120 </td>
+            <td></td>
+            <td> <br> Time after which the connection will get terminated.  <br> It is to be mentioned in seconds. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > port</td>
+            <td> int  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Port number for the PowerStore array.  <br> If not passed, it will take 443 as default. </td>
+        </tr>
+                                                    </table>
 
 ### Notes
 * The check_mode is not supported.
@@ -3099,7 +3572,13 @@ Manage host group on PowerStore Storage System
         <th>Returned</th>
         <th width="100%">Description</th>
     </tr>
-                                    <tr>
+                                                                                            <tr>
+            <td colspan=3 > changed </td>
+            <td>  bool </td>
+            <td> always </td>
+            <td> Whether or not the resource has changed. </td>
+        </tr>
+                    <tr>
             <td colspan=3 > hostgroup_details </td>
             <td>  complex </td>
             <td> When host group exists </td>
@@ -3107,17 +3586,10 @@ Manage host group on PowerStore Storage System
         </tr>
                             <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > name </td>
+                <td colspan=2 > description </td>
                 <td> str </td>
                 <td>success</td>
-                <td> Name of the host group. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > id </td>
-                <td> str </td>
-                <td>success</td>
-                <td> The system generated ID given to the host group. </td>
+                <td> Description about the host group. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
@@ -3129,33 +3601,34 @@ Manage host group on PowerStore Storage System
                                          <tr>
                     <td class="elbow-placeholder">&nbsp;</td>
                     <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=1 > name </td>
-                    <td> str </td>
-                    <td>success</td>
-                    <td> The name of the host. </td>
-                </tr>
-                                             <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
                     <td colspan=1 > id </td>
                     <td> str </td>
                     <td>success</td>
                     <td> The ID of the host. </td>
                 </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=1 > name </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> The name of the host. </td>
+                </tr>
                                                             <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > description </td>
+                <td colspan=2 > id </td>
                 <td> str </td>
                 <td>success</td>
-                <td> Description about the host group. </td>
+                <td> The system generated ID given to the host group. </td>
             </tr>
-                                        <tr>
-            <td colspan=3 > changed </td>
-            <td>  bool </td>
-            <td> always </td>
-            <td> Whether or not the resource has changed. </td>
-        </tr>
-                                                                            </table>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > name </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Name of the host group. </td>
+            </tr>
+                                        </table>
 
 ### Authors
 * Manisha Agrawal (@agrawm3) <ansible.team@dell.com>
@@ -3174,7 +3647,7 @@ Gathers information about PowerStore Storage entities
  It also includes DNS/NTP servers, smtp configs, email destinations, remote support, remote support contacts.
 
 ### Parameters
-                                                                                                                                                                                                                                                                            
+                                                                                                                                                                                                                                                                                                                                                
 <table>
     <tr>
         <th colspan=2>Parameter</th>
@@ -3184,53 +3657,13 @@ Gathers information about PowerStore Storage entities
         <th>Choices</th>
         <th width="80%">Description</th>
     </tr>
-                    <tr>
+                                                            <tr>
             <td colspan=2 > gather_subset</td>
             <td> list   <br> elements: str </td>
             <td> True </td>
             <td></td>
             <td> <ul> <li>vol</li>  <li>vg</li>  <li>host</li>  <li>hg</li>  <li>node</li>  <li>protection_policy</li>  <li>snapshot_rule</li>  <li>nas_server</li>  <li>nfs_export</li>  <li>smb_share</li>  <li>tree_quota</li>  <li>user_quota</li>  <li>file_system</li>  <li>replication_rule</li>  <li>replication_session</li>  <li>remote_system</li>  <li>network</li>  <li>role</li>  <li>ldap_account</li>  <li>user</li>  <li>appliance</li>  <li>ad</li>  <li>ldap</li>  <li>security_config</li>  <li>certificate</li>  <li>dns</li>  <li>ntp</li>  <li>smtp_config</li>  <li>email_notification</li>  <li>remote_support</li>  <li>remote_support_contact</li>  <li>ldap_domain</li> </ul></td>
             <td> <br> A list of string variables which specify the PowerStore system entities requiring information.  <br> Volumes - vol.  <br> All the nodes - node.  <br> Volume groups - vg.  <br> Protection policies - protection_policy.  <br> Hosts - host.  <br> Host groups - hg.  <br> Snapshot rules - snapshot_rule.  <br> NAS servers - nas_server.  <br> NFS exports - nfs_export.  <br> SMB shares - smb_share.  <br> Tree quotas - tree_quota.  <br> User quotas - user_quota.  <br> File systems - file_system.  <br> Replication rules - replication_rule.  <br> Replication sessions - replication_session.  <br> Remote systems - remote_system.  <br> Various networks - network.  <br> Roles - role.  <br> Local users - user.  <br> Appliances - appliance.  <br> Security configurations - security_config.  <br> Certificates - certificate.  <br> Active directories - ad.  <br> LDAPs - ldap.  <br> DNS servers - dns.  <br> NTP servers - ntp.  <br> Email notification destinations - email_notification.  <br> SMTP configurations - smtp_config.  <br> Remote Support - remote_support.  <br> Remote support contacts - remote_support_contact.  <br> LDAP accounts - ldap_account.  <br> LDAP domain - ldap_domain. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > timeout</td>
-            <td> int  </td>
-            <td></td>
-            <td> 120 </td>
-            <td></td>
-            <td> <br> Time after which the connection will get terminated.  <br> It is to be mentioned in seconds. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > user</td>
-            <td> str  </td>
-            <td> True </td>
-            <td></td>
-            <td></td>
-            <td> <br> The username of the PowerStore host. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > array_ip</td>
-            <td> str  </td>
-            <td> True </td>
-            <td></td>
-            <td></td>
-            <td> <br> IP or FQDN of the PowerStore management system. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > all_pages</td>
-            <td> bool  </td>
-            <td></td>
-            <td> False </td>
-            <td></td>
-            <td> <br> Indicates whether to return all available entities on the storage system.  <br> If set to True, the Info module will implement pagination and return all entities. Otherwise, a maximum of the first 100 entities of any type will be returned. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > port</td>
-            <td> int  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Port number for the PowerStore array.  <br> If not passed, it will take 443 as default. </td>
         </tr>
                     <tr>
             <td colspan=2 > filters</td>
@@ -3242,15 +3675,6 @@ Gathers information about PowerStore Storage entities
         </tr>
                             <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > filter_operator </td>
-                <td> str  </td>
-                <td> True </td>
-                <td></td>
-                <td> <ul> <li>equal</li>  <li>greater</li>  <li>lesser</li>  <li>like</li>  <li>notequal</li> </ul></td>
-                <td>  <br> Operation to be performed on the filter key.  </td>
-            </tr>
-                    <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=1 > filter_key </td>
                 <td> str  </td>
                 <td> True </td>
@@ -3258,7 +3682,16 @@ Gathers information about PowerStore Storage entities
                 <td></td>
                 <td>  <br> Name identifier of the filter.  </td>
             </tr>
-                    <tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > filter_operator </td>
+                <td> str  </td>
+                <td> True </td>
+                <td></td>
+                <td> <ul> <li>equal</li>  <li>greater</li>  <li>lesser</li>  <li>like</li>  <li>notequal</li> </ul></td>
+                <td>  <br> Operation to be performed on the filter key.  </td>
+            </tr>
+                                <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=1 > filter_value </td>
                 <td> str  </td>
@@ -3267,13 +3700,21 @@ Gathers information about PowerStore Storage entities
                 <td></td>
                 <td>  <br> Value of the filter key.  </td>
             </tr>
-                            <tr>
-            <td colspan=2 > password</td>
+                                        <tr>
+            <td colspan=2 > all_pages</td>
+            <td> bool  </td>
+            <td></td>
+            <td> False </td>
+            <td></td>
+            <td> <br> Indicates whether to return all available entities on the storage system.  <br> If set to True, the Info module will implement pagination and return all entities. Otherwise, a maximum of the first 100 entities of any type will be returned. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > array_ip</td>
             <td> str  </td>
             <td> True </td>
             <td></td>
             <td></td>
-            <td> <br> The password of the PowerStore host. </td>
+            <td> <br> IP or FQDN of the PowerStore management system. </td>
         </tr>
                     <tr>
             <td colspan=2 > verifycert</td>
@@ -3283,7 +3724,39 @@ Gathers information about PowerStore Storage entities
             <td> <ul> <li>True</li>  <li>False</li> </ul></td>
             <td> <br> Boolean variable to specify whether to validate SSL certificate or not.  <br> True - indicates that the SSL certificate should be verified. Set the environment variable REQUESTS_CA_BUNDLE to the path of the SSL certificate.  <br> False - indicates that the SSL certificate should not be verified. </td>
         </tr>
-                                                                                            </table>
+                    <tr>
+            <td colspan=2 > user</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td></td>
+            <td> <br> The username of the PowerStore host. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > password</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td></td>
+            <td> <br> The password of the PowerStore host. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > timeout</td>
+            <td> int  </td>
+            <td></td>
+            <td> 120 </td>
+            <td></td>
+            <td> <br> Time after which the connection will get terminated.  <br> It is to be mentioned in seconds. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > port</td>
+            <td> int  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Port number for the PowerStore array.  <br> If not passed, it will take 443 as default. </td>
+        </tr>
+                                                    </table>
 
 ### Notes
 * Pagination is not supported for role, local user, security configs, LDAP accounts and LDAP domain. If all_pages is passed, it will be ignored.
@@ -3521,260 +3994,7 @@ Gathers information about PowerStore Storage entities
         <th>Returned</th>
         <th width="100%">Description</th>
     </tr>
-                                    <tr>
-            <td colspan=2 > TreeQuotas </td>
-            <td>  list </td>
-            <td> When tree_quota is in a given gather_subset </td>
-            <td> Provides details of all tree quotas. </td>
-        </tr>
-                            <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > id </td>
-                <td> str </td>
-                <td>success</td>
-                <td> ID of the tree quota. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > path </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Path of the tree quota. </td>
-            </tr>
-                                        <tr>
-            <td colspan=2 > Hosts </td>
-            <td>  list </td>
-            <td> When host is in a given gather_subset </td>
-            <td> Provides details of all hosts. </td>
-        </tr>
-                            <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > name </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Name of the host. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > id </td>
-                <td> str </td>
-                <td>success</td>
-                <td> ID of the host. </td>
-            </tr>
-                                        <tr>
-            <td colspan=2 > Volumes </td>
-            <td>  list </td>
-            <td> When vol is in a given gather_subset </td>
-            <td> Provides details of all volumes. </td>
-        </tr>
-                            <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > name </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Name of the volume. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > id </td>
-                <td> str </td>
-                <td>success</td>
-                <td> ID of the volume. </td>
-            </tr>
-                                        <tr>
-            <td colspan=2 > SMBShares </td>
-            <td>  list </td>
-            <td> When smb_share is in a given gather_subset </td>
-            <td> Provides details of all smb shares. </td>
-        </tr>
-                            <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > name </td>
-                <td> str </td>
-                <td>success</td>
-                <td> name of the smb share. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > id </td>
-                <td> str </td>
-                <td>success</td>
-                <td> ID of the smb share. </td>
-            </tr>
-                                        <tr>
-            <td colspan=2 > NFSExports </td>
-            <td>  list </td>
-            <td> When nfs_export is in a given gather_subset </td>
-            <td> Provides details of all nfs exports. </td>
-        </tr>
-                            <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > name </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Name of the nfs export. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > id </td>
-                <td> str </td>
-                <td>success</td>
-                <td> ID of the nfs export. </td>
-            </tr>
-                                        <tr>
-            <td colspan=2 > LDAPAccounts </td>
-            <td>  list </td>
-            <td> When LDAP account is in a given gather_subset </td>
-            <td> Provides details of all LDAP accounts. </td>
-        </tr>
-                            <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > name </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Name of the LDAP account. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > domain_id </td>
-                <td> int </td>
-                <td>success</td>
-                <td> Unique identifier of the LDAP domain to which LDAP user or group belongs. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > role_id </td>
-                <td> int </td>
-                <td>success</td>
-                <td> Unique identifier of the role to which the LDAP account is mapped. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > id </td>
-                <td> str </td>
-                <td>success</td>
-                <td> ID of the LDAP account. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > type </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Type of LDAP account. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > dn </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Types of directory service protocol. </td>
-            </tr>
-                                        <tr>
-            <td colspan=2 > NTP </td>
-            <td>  list </td>
-            <td> When ntp is in a given gather_subset </td>
-            <td> Provides details of all NTP servers. </td>
-        </tr>
-                            <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > id </td>
-                <td> str </td>
-                <td>success</td>
-                <td> ID of the NTP server. </td>
-            </tr>
-                                        <tr>
-            <td colspan=2 > SecurityConfig </td>
-            <td>  list </td>
-            <td> When security_config is in a given gather_subset </td>
-            <td> Provides details of all security configs. </td>
-        </tr>
-                            <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > id </td>
-                <td> str </td>
-                <td>success</td>
-                <td> ID of the security config. </td>
-            </tr>
-                                        <tr>
-            <td colspan=2 > RemoteSupport </td>
-            <td>  list </td>
-            <td> When remote_support is in a given gather_subset </td>
-            <td> Provides details of all remote support config. </td>
-        </tr>
-                            <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > id </td>
-                <td> str </td>
-                <td>success</td>
-                <td> ID of the remote support. </td>
-            </tr>
-                                        <tr>
-            <td colspan=2 > Appliance </td>
-            <td>  list </td>
-            <td> When appliance is in a given gather_subset </td>
-            <td> Provides details of all appliances. </td>
-        </tr>
-                            <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > name </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Name of the appliance. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > id </td>
-                <td> str </td>
-                <td>success</td>
-                <td> ID of the appliance. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > model </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Model type of the PowerStore. </td>
-            </tr>
-                                        <tr>
-            <td colspan=2 > UserQuotas </td>
-            <td>  list </td>
-            <td> When user_quota is in a given gather_subset </td>
-            <td> Provides details of all user quotas. </td>
-        </tr>
-                            <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > id </td>
-                <td> str </td>
-                <td>success</td>
-                <td> ID of the user quota. </td>
-            </tr>
-                                        <tr>
-            <td colspan=2 > ProtectionPolicies </td>
-            <td>  list </td>
-            <td> When protection_policy is in a given gather_subset </td>
-            <td> Provides details of all protection policies. </td>
-        </tr>
-                            <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > name </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Name of the protection policy. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > id </td>
-                <td> str </td>
-                <td>success</td>
-                <td> ID of the protection policy. </td>
-            </tr>
-                                        <tr>
-            <td colspan=2 > Array_Software_Version </td>
-            <td>  str </td>
-            <td> always </td>
-            <td> API version of PowerStore array. </td>
-        </tr>
-                    <tr>
+                                                                                            <tr>
             <td colspan=2 > ActiveDirectory </td>
             <td>  list </td>
             <td> When ad is in a given gather_subset </td>
@@ -3788,23 +4008,50 @@ Gathers information about PowerStore Storage entities
                 <td> ID of the active directory. </td>
             </tr>
                                         <tr>
-            <td colspan=2 > changed </td>
-            <td>  bool </td>
-            <td> always </td>
-            <td> Shows whether or not the resource has changed. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > LDAP </td>
+            <td colspan=2 > Appliance </td>
             <td>  list </td>
-            <td> When ldap is in a given gather_subset </td>
-            <td> Provides details of all LDAPs. </td>
+            <td> When appliance is in a given gather_subset </td>
+            <td> Provides details of all appliances. </td>
         </tr>
                             <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=1 > id </td>
                 <td> str </td>
                 <td>success</td>
-                <td> ID of the LDAP. </td>
+                <td> ID of the appliance. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > model </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Model type of the PowerStore. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > name </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Name of the appliance. </td>
+            </tr>
+                                        <tr>
+            <td colspan=2 > Array_Software_Version </td>
+            <td>  str </td>
+            <td> always </td>
+            <td> API version of PowerStore array. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > Certificate </td>
+            <td>  list </td>
+            <td> When certificates is in a given gather_subset </td>
+            <td> Provides details of all certificates. </td>
+        </tr>
+                            <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > id </td>
+                <td> str </td>
+                <td>success</td>
+                <td> ID of the certificate. </td>
             </tr>
                                         <tr>
             <td colspan=2 > Cluster </td>
@@ -3814,222 +4061,30 @@ Gathers information about PowerStore Storage entities
         </tr>
                             <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > name </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Name of the cluster. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=1 > id </td>
                 <td> str </td>
                 <td>success</td>
                 <td> ID of the cluster. </td>
             </tr>
-                                        <tr>
-            <td colspan=2 > LocalUsers </td>
-            <td>  list </td>
-            <td> When user is in a given gather_subset </td>
-            <td> Provides details of all local users. </td>
-        </tr>
-                            <tr>
+                                <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=1 > name </td>
                 <td> str </td>
                 <td>success</td>
-                <td> Name of the user. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > id </td>
-                <td> str </td>
-                <td>success</td>
-                <td> ID of the user. </td>
+                <td> Name of the cluster. </td>
             </tr>
                                         <tr>
-            <td colspan=2 > ReplicationSession </td>
+            <td colspan=2 > DNS </td>
             <td>  list </td>
-            <td> when replication_session given in gather_subset </td>
-            <td> Details of all replication sessions. </td>
+            <td> When dns is in a given gather_subset </td>
+            <td> Provides details of all DNS servers. </td>
         </tr>
                             <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=1 > id </td>
                 <td> str </td>
                 <td>success</td>
-                <td> ID of the replication session. </td>
-            </tr>
-                                        <tr>
-            <td colspan=2 > RemoteSystems </td>
-            <td>  list </td>
-            <td> When remote_system is in a given gather_subset </td>
-            <td> Provides details of all remote systems. </td>
-        </tr>
-                            <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > name </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Name of the remote system. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > id </td>
-                <td> str </td>
-                <td>success</td>
-                <td> ID of the remote system. </td>
-            </tr>
-                                        <tr>
-            <td colspan=2 > LDAPDomain </td>
-            <td>  list </td>
-            <td> When LDAP domain configuration is in a given gather_subset </td>
-            <td> Provides details of the LDAP domain configurations. </td>
-        </tr>
-                            <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > id </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Unique identifier of the new LDAP server configuration. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > protocol </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Types of directory service protocol. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > ldap_server_type </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Types of LDAP server. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > port </td>
-                <td> int </td>
-                <td>success</td>
-                <td> Port number used to connect to the LDAP server(s). </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > ldap_servers </td>
-                <td> list </td>
-                <td>success</td>
-                <td> List of IP addresses of the LDAP servers for the domain. IP addresses are in IPv4 format. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > ldap_server_type_l10n </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Localized message string corresponding to ldap_server_type. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > protocol_l10n </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Localized message string corresponding to protocol. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > ldap_timeout </td>
-                <td> int </td>
-                <td>success</td>
-                <td> Timeout for establishing a connection to an LDAP server. Default value is 30000 (30 seconds). </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > is_global_catalog </td>
-                <td> bool </td>
-                <td>success</td>
-                <td> Whether or not the catalog is global. Default value is false. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > bind_user </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Distinguished Name (DN) of the user to be used when binding. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > group_object_class </td>
-                <td> str </td>
-                <td>success</td>
-                <td> LDAP object class for groups. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > group_name_attribute </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Name of the LDAP attribute whose value indicates the group name. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > group_member_attribute </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Name of the LDAP attribute whose value contains the names of group members within a group. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > group_search_path </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Path used to search for groups on the directory server. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > group_search_level </td>
-                <td> int </td>
-                <td>success</td>
-                <td> Nested search level for performing group search. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > user_object_class </td>
-                <td> str </td>
-                <td>success</td>
-                <td> LDAP object class for users. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > user_id_attribute </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Name of the LDAP attribute whose value indicates the unique identifier of the user. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > domain_name </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Name of the LDAP authority to construct the LDAP server configuration. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > user_search_path </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Path used to search for users on the directory server. </td>
-            </tr>
-                                        <tr>
-            <td colspan=2 > RemoteSupportContact </td>
-            <td>  list </td>
-            <td> When remote_support_contact is in a given gather_subset </td>
-            <td> Provides details of all remote support contacts. </td>
-        </tr>
-                            <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > id </td>
-                <td> str </td>
-                <td>success</td>
-                <td> ID of the remote support contact. </td>
+                <td> ID of the DNS server. </td>
             </tr>
                                         <tr>
             <td colspan=2 > EmailNotification </td>
@@ -4052,24 +4107,284 @@ Gathers information about PowerStore Storage entities
                 <td> ID of the email. </td>
             </tr>
                                         <tr>
-            <td colspan=2 > Nodes </td>
+            <td colspan=2 > FileSystems </td>
             <td>  list </td>
-            <td> When a node is in a given gather_subset </td>
-            <td> Provides details of all nodes. </td>
+            <td> When file_system is in a given gather_subset </td>
+            <td> Provides details of all filesystems. </td>
         </tr>
                             <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > id </td>
+                <td> str </td>
+                <td>success</td>
+                <td> ID of the filesystem. </td>
+            </tr>
+                                <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=1 > name </td>
                 <td> str </td>
                 <td>success</td>
-                <td> Name of the node. </td>
+                <td> Name of the filesystem. </td>
+            </tr>
+                                        <tr>
+            <td colspan=2 > HostGroups </td>
+            <td>  list </td>
+            <td> When hg is in a given gather_subset </td>
+            <td> Provides details of all host groups. </td>
+        </tr>
+                            <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > id </td>
+                <td> str </td>
+                <td>success</td>
+                <td> ID of the host group. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > name </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Name of the host group. </td>
+            </tr>
+                                        <tr>
+            <td colspan=2 > Hosts </td>
+            <td>  list </td>
+            <td> When host is in a given gather_subset </td>
+            <td> Provides details of all hosts. </td>
+        </tr>
+                            <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > id </td>
+                <td> str </td>
+                <td>success</td>
+                <td> ID of the host. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > name </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Name of the host. </td>
+            </tr>
+                                        <tr>
+            <td colspan=2 > LDAP </td>
+            <td>  list </td>
+            <td> When ldap is in a given gather_subset </td>
+            <td> Provides details of all LDAPs. </td>
+        </tr>
+                            <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > id </td>
+                <td> str </td>
+                <td>success</td>
+                <td> ID of the LDAP. </td>
+            </tr>
+                                        <tr>
+            <td colspan=2 > LDAPAccounts </td>
+            <td>  list </td>
+            <td> When LDAP account is in a given gather_subset </td>
+            <td> Provides details of all LDAP accounts. </td>
+        </tr>
+                            <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > dn </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Types of directory service protocol. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > domain_id </td>
+                <td> int </td>
+                <td>success</td>
+                <td> Unique identifier of the LDAP domain to which LDAP user or group belongs. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=1 > id </td>
                 <td> str </td>
                 <td>success</td>
-                <td> ID of the node. </td>
+                <td> ID of the LDAP account. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > name </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Name of the LDAP account. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > role_id </td>
+                <td> int </td>
+                <td>success</td>
+                <td> Unique identifier of the role to which the LDAP account is mapped. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > type </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Type of LDAP account. </td>
+            </tr>
+                                        <tr>
+            <td colspan=2 > LDAPDomain </td>
+            <td>  list </td>
+            <td> When LDAP domain configuration is in a given gather_subset </td>
+            <td> Provides details of the LDAP domain configurations. </td>
+        </tr>
+                            <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > bind_user </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Distinguished Name (DN) of the user to be used when binding. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > domain_name </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Name of the LDAP authority to construct the LDAP server configuration. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > group_member_attribute </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Name of the LDAP attribute whose value contains the names of group members within a group. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > group_name_attribute </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Name of the LDAP attribute whose value indicates the group name. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > group_object_class </td>
+                <td> str </td>
+                <td>success</td>
+                <td> LDAP object class for groups. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > group_search_level </td>
+                <td> int </td>
+                <td>success</td>
+                <td> Nested search level for performing group search. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > group_search_path </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Path used to search for groups on the directory server. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > id </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Unique identifier of the new LDAP server configuration. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > is_global_catalog </td>
+                <td> bool </td>
+                <td>success</td>
+                <td> Whether or not the catalog is global. Default value is false. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > ldap_server_type </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Types of LDAP server. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > ldap_server_type_l10n </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Localized message string corresponding to ldap_server_type. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > ldap_servers </td>
+                <td> list </td>
+                <td>success</td>
+                <td> List of IP addresses of the LDAP servers for the domain. IP addresses are in IPv4 format. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > ldap_timeout </td>
+                <td> int </td>
+                <td>success</td>
+                <td> Timeout for establishing a connection to an LDAP server. Default value is 30000 (30 seconds). </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > port </td>
+                <td> int </td>
+                <td>success</td>
+                <td> Port number used to connect to the LDAP server(s). </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > protocol </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Types of directory service protocol. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > protocol_l10n </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Localized message string corresponding to protocol. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > user_id_attribute </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Name of the LDAP attribute whose value indicates the unique identifier of the user. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > user_object_class </td>
+                <td> str </td>
+                <td>success</td>
+                <td> LDAP object class for users. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > user_search_path </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Path used to search for users on the directory server. </td>
+            </tr>
+                                        <tr>
+            <td colspan=2 > LocalUsers </td>
+            <td>  list </td>
+            <td> When user is in a given gather_subset </td>
+            <td> Provides details of all local users. </td>
+        </tr>
+                            <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > id </td>
+                <td> str </td>
+                <td>success</td>
+                <td> ID of the user. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > name </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Name of the user. </td>
             </tr>
                                         <tr>
             <td colspan=2 > NASServers </td>
@@ -4079,57 +4394,50 @@ Gathers information about PowerStore Storage entities
         </tr>
                             <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > name </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Name of the nas server. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=1 > id </td>
                 <td> str </td>
                 <td>success</td>
                 <td> ID of the nas server. </td>
             </tr>
-                                        <tr>
-            <td colspan=2 > SnapshotRules </td>
-            <td>  list </td>
-            <td> When snapshot_rule is in a given gather_subset </td>
-            <td> Provides details of all snapshot rules. </td>
-        </tr>
-                            <tr>
+                                <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=1 > name </td>
                 <td> str </td>
                 <td>success</td>
-                <td> Name of the snapshot rule. </td>
+                <td> Name of the nas server. </td>
             </tr>
-                                <tr>
+                                        <tr>
+            <td colspan=2 > NFSExports </td>
+            <td>  list </td>
+            <td> When nfs_export is in a given gather_subset </td>
+            <td> Provides details of all nfs exports. </td>
+        </tr>
+                            <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=1 > id </td>
                 <td> str </td>
                 <td>success</td>
-                <td> ID of the snapshot rule. </td>
+                <td> ID of the nfs export. </td>
             </tr>
-                                        <tr>
-            <td colspan=2 > FileSystems </td>
-            <td>  list </td>
-            <td> When file_system is in a given gather_subset </td>
-            <td> Provides details of all filesystems. </td>
-        </tr>
-                            <tr>
+                                <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=1 > name </td>
                 <td> str </td>
                 <td>success</td>
-                <td> Name of the filesystem. </td>
+                <td> Name of the nfs export. </td>
             </tr>
-                                <tr>
+                                        <tr>
+            <td colspan=2 > NTP </td>
+            <td>  list </td>
+            <td> When ntp is in a given gather_subset </td>
+            <td> Provides details of all NTP servers. </td>
+        </tr>
+                            <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=1 > id </td>
                 <td> str </td>
                 <td>success</td>
-                <td> ID of the filesystem. </td>
+                <td> ID of the NTP server. </td>
             </tr>
                                         <tr>
             <td colspan=2 > Networks </td>
@@ -4139,63 +4447,176 @@ Gathers information about PowerStore Storage entities
         </tr>
                             <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > name </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Name of the network. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=1 > id </td>
                 <td> str </td>
                 <td>success</td>
                 <td> ID of the network. </td>
             </tr>
-                                        <tr>
-            <td colspan=2 > DNS </td>
-            <td>  list </td>
-            <td> When dns is in a given gather_subset </td>
-            <td> Provides details of all DNS servers. </td>
-        </tr>
-                            <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > id </td>
-                <td> str </td>
-                <td>success</td>
-                <td> ID of the DNS server. </td>
-            </tr>
-                                        <tr>
-            <td colspan=2 > Certificate </td>
-            <td>  list </td>
-            <td> When certificates is in a given gather_subset </td>
-            <td> Provides details of all certificates. </td>
-        </tr>
-                            <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > id </td>
-                <td> str </td>
-                <td>success</td>
-                <td> ID of the certificate. </td>
-            </tr>
-                                        <tr>
-            <td colspan=2 > VolumeGroups </td>
-            <td>  list </td>
-            <td> When vg is in a given gather_subset </td>
-            <td> Provides details of all volume groups. </td>
-        </tr>
-                            <tr>
+                                <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=1 > name </td>
                 <td> str </td>
                 <td>success</td>
-                <td> Name of the volume group. </td>
+                <td> Name of the network. </td>
             </tr>
-                                <tr>
+                                        <tr>
+            <td colspan=2 > Nodes </td>
+            <td>  list </td>
+            <td> When a node is in a given gather_subset </td>
+            <td> Provides details of all nodes. </td>
+        </tr>
+                            <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=1 > id </td>
                 <td> str </td>
                 <td>success</td>
-                <td> ID of the volume group. </td>
+                <td> ID of the node. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > name </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Name of the node. </td>
+            </tr>
+                                        <tr>
+            <td colspan=2 > ProtectionPolicies </td>
+            <td>  list </td>
+            <td> When protection_policy is in a given gather_subset </td>
+            <td> Provides details of all protection policies. </td>
+        </tr>
+                            <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > id </td>
+                <td> str </td>
+                <td>success</td>
+                <td> ID of the protection policy. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > name </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Name of the protection policy. </td>
+            </tr>
+                                        <tr>
+            <td colspan=2 > RemoteSupport </td>
+            <td>  list </td>
+            <td> When remote_support is in a given gather_subset </td>
+            <td> Provides details of all remote support config. </td>
+        </tr>
+                            <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > id </td>
+                <td> str </td>
+                <td>success</td>
+                <td> ID of the remote support. </td>
+            </tr>
+                                        <tr>
+            <td colspan=2 > RemoteSupportContact </td>
+            <td>  list </td>
+            <td> When remote_support_contact is in a given gather_subset </td>
+            <td> Provides details of all remote support contacts. </td>
+        </tr>
+                            <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > id </td>
+                <td> str </td>
+                <td>success</td>
+                <td> ID of the remote support contact. </td>
+            </tr>
+                                        <tr>
+            <td colspan=2 > RemoteSystems </td>
+            <td>  list </td>
+            <td> When remote_system is in a given gather_subset </td>
+            <td> Provides details of all remote systems. </td>
+        </tr>
+                            <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > id </td>
+                <td> str </td>
+                <td>success</td>
+                <td> ID of the remote system. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > name </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Name of the remote system. </td>
+            </tr>
+                                        <tr>
+            <td colspan=2 > ReplicationRules </td>
+            <td>  list </td>
+            <td> When replication_rule is in a given gather_subset </td>
+            <td> Provides details of all replication rules. </td>
+        </tr>
+                            <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > id </td>
+                <td> str </td>
+                <td>success</td>
+                <td> ID of the replication rule. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > name </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Name of the replication rule. </td>
+            </tr>
+                                        <tr>
+            <td colspan=2 > ReplicationSession </td>
+            <td>  list </td>
+            <td> when replication_session given in gather_subset </td>
+            <td> Details of all replication sessions. </td>
+        </tr>
+                            <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > id </td>
+                <td> str </td>
+                <td>success</td>
+                <td> ID of the replication session. </td>
+            </tr>
+                                        <tr>
+            <td colspan=2 > Roles </td>
+            <td>  list </td>
+            <td> When role is in a given gather_subset </td>
+            <td> Provides details of all roles. </td>
+        </tr>
+                            <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > id </td>
+                <td> str </td>
+                <td>success</td>
+                <td> ID of the role. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > name </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Name of the role. </td>
+            </tr>
+                                        <tr>
+            <td colspan=2 > SMBShares </td>
+            <td>  list </td>
+            <td> When smb_share is in a given gather_subset </td>
+            <td> Provides details of all smb shares. </td>
+        </tr>
+                            <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > id </td>
+                <td> str </td>
+                <td>success</td>
+                <td> ID of the smb share. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > name </td>
+                <td> str </td>
+                <td>success</td>
+                <td> name of the smb share. </td>
             </tr>
                                         <tr>
             <td colspan=2 > SMTPConfig </td>
@@ -4211,66 +4632,118 @@ Gathers information about PowerStore Storage entities
                 <td> ID of the smtp config. </td>
             </tr>
                                         <tr>
-            <td colspan=2 > Roles </td>
+            <td colspan=2 > SecurityConfig </td>
             <td>  list </td>
-            <td> When role is in a given gather_subset </td>
-            <td> Provides details of all roles. </td>
+            <td> When security_config is in a given gather_subset </td>
+            <td> Provides details of all security configs. </td>
         </tr>
                             <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > name </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Name of the role. </td>
-            </tr>
-                                <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=1 > id </td>
                 <td> str </td>
                 <td>success</td>
-                <td> ID of the role. </td>
+                <td> ID of the security config. </td>
             </tr>
                                         <tr>
-            <td colspan=2 > ReplicationRules </td>
+            <td colspan=2 > SnapshotRules </td>
             <td>  list </td>
-            <td> When replication_rule is in a given gather_subset </td>
-            <td> Provides details of all replication rules. </td>
+            <td> When snapshot_rule is in a given gather_subset </td>
+            <td> Provides details of all snapshot rules. </td>
         </tr>
                             <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > name </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Name of the replication rule. </td>
-            </tr>
-                                <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=1 > id </td>
                 <td> str </td>
                 <td>success</td>
-                <td> ID of the replication rule. </td>
+                <td> ID of the snapshot rule. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > name </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Name of the snapshot rule. </td>
             </tr>
                                         <tr>
-            <td colspan=2 > HostGroups </td>
+            <td colspan=2 > TreeQuotas </td>
             <td>  list </td>
-            <td> When hg is in a given gather_subset </td>
-            <td> Provides details of all host groups. </td>
+            <td> When tree_quota is in a given gather_subset </td>
+            <td> Provides details of all tree quotas. </td>
         </tr>
                             <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > name </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Name of the host group. </td>
-            </tr>
-                                <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=1 > id </td>
                 <td> str </td>
                 <td>success</td>
-                <td> ID of the host group. </td>
+                <td> ID of the tree quota. </td>
             </tr>
-                                                                                                </table>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > path </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Path of the tree quota. </td>
+            </tr>
+                                        <tr>
+            <td colspan=2 > UserQuotas </td>
+            <td>  list </td>
+            <td> When user_quota is in a given gather_subset </td>
+            <td> Provides details of all user quotas. </td>
+        </tr>
+                            <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > id </td>
+                <td> str </td>
+                <td>success</td>
+                <td> ID of the user quota. </td>
+            </tr>
+                                        <tr>
+            <td colspan=2 > VolumeGroups </td>
+            <td>  list </td>
+            <td> When vg is in a given gather_subset </td>
+            <td> Provides details of all volume groups. </td>
+        </tr>
+                            <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > id </td>
+                <td> str </td>
+                <td>success</td>
+                <td> ID of the volume group. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > name </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Name of the volume group. </td>
+            </tr>
+                                        <tr>
+            <td colspan=2 > Volumes </td>
+            <td>  list </td>
+            <td> When vol is in a given gather_subset </td>
+            <td> Provides details of all volumes. </td>
+        </tr>
+                            <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > id </td>
+                <td> str </td>
+                <td>success</td>
+                <td> ID of the volume. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > name </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Name of the volume. </td>
+            </tr>
+                                        <tr>
+            <td colspan=2 > changed </td>
+            <td>  bool </td>
+            <td> always </td>
+            <td> Shows whether or not the resource has changed. </td>
+        </tr>
+                    </table>
 
 ### Authors
 * Arindam Datta (@dattaarindam) <ansible.team@dell.com>
@@ -4296,21 +4769,13 @@ Manage jobs for PowerStore
         <th>Choices</th>
         <th width="80%">Description</th>
     </tr>
-                    <tr>
-            <td colspan=1 > timeout</td>
-            <td> int  </td>
-            <td></td>
-            <td> 120 </td>
-            <td></td>
-            <td> <br> Time after which the connection will get terminated.  <br> It is to be mentioned in seconds. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > user</td>
+                                                            <tr>
+            <td colspan=1 > job_id</td>
             <td> str  </td>
             <td> True </td>
             <td></td>
             <td></td>
-            <td> <br> The username of the PowerStore host. </td>
+            <td> <br> The ID of the job. </td>
         </tr>
                     <tr>
             <td colspan=1 > array_ip</td>
@@ -4321,14 +4786,6 @@ Manage jobs for PowerStore
             <td> <br> IP or FQDN of the PowerStore management system. </td>
         </tr>
                     <tr>
-            <td colspan=1 > job_id</td>
-            <td> str  </td>
-            <td> True </td>
-            <td></td>
-            <td></td>
-            <td> <br> The ID of the job. </td>
-        </tr>
-                    <tr>
             <td colspan=1 > verifycert</td>
             <td> bool  </td>
             <td> True </td>
@@ -4337,12 +4794,12 @@ Manage jobs for PowerStore
             <td> <br> Boolean variable to specify whether to validate SSL certificate or not.  <br> True - indicates that the SSL certificate should be verified. Set the environment variable REQUESTS_CA_BUNDLE to the path of the SSL certificate.  <br> False - indicates that the SSL certificate should not be verified. </td>
         </tr>
                     <tr>
-            <td colspan=1 > port</td>
-            <td> int  </td>
+            <td colspan=1 > user</td>
+            <td> str  </td>
+            <td> True </td>
             <td></td>
             <td></td>
-            <td></td>
-            <td> <br> Port number for the PowerStore array.  <br> If not passed, it will take 443 as default. </td>
+            <td> <br> The username of the PowerStore host. </td>
         </tr>
                     <tr>
             <td colspan=1 > password</td>
@@ -4352,7 +4809,23 @@ Manage jobs for PowerStore
             <td></td>
             <td> <br> The password of the PowerStore host. </td>
         </tr>
-                                                                                            </table>
+                    <tr>
+            <td colspan=1 > timeout</td>
+            <td> int  </td>
+            <td></td>
+            <td> 120 </td>
+            <td></td>
+            <td> <br> Time after which the connection will get terminated.  <br> It is to be mentioned in seconds. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > port</td>
+            <td> int  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Port number for the PowerStore array.  <br> If not passed, it will take 443 as default. </td>
+        </tr>
+                                                    </table>
 
 ### Notes
 * The check_mode is not supported.
@@ -4378,7 +4851,7 @@ Manage jobs for PowerStore
         <th>Returned</th>
         <th width="100%">Description</th>
     </tr>
-                                    <tr>
+                                                                                            <tr>
             <td colspan=4 > changed </td>
             <td>  bool </td>
             <td> always </td>
@@ -4392,52 +4865,24 @@ Manage jobs for PowerStore
         </tr>
                             <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=3 > resource_name </td>
+                <td colspan=3 > description_l10n </td>
                 <td> str </td>
                 <td>success</td>
-                <td> Name of the resource on which the job is operating. </td>
+                <td> Description of the job. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=3 > resource_action </td>
+                <td colspan=3 > end_time </td>
                 <td> str </td>
                 <td>success</td>
-                <td> User-specified action to be performed on the given resource. </td>
+                <td> Date and time when the job execution completed. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=3 > step_order </td>
-                <td> int </td>
-                <td>success</td>
-                <td> Order of a given job step with respect to its siblings within the job hierarchy. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=3 > start_time </td>
+                <td colspan=3 > estimated_completion_time </td>
                 <td> str </td>
                 <td>success</td>
-                <td> Date and time when the job execution started. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=3 > parent_id </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Unique identifier of the parent job, if applicable. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=3 > root_id </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Unique identifier of the root job, if applicable. The root job is the job at the top of the parent hierarchy. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=3 > response_status </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Possible HTTP status values of completed or failed jobs. </td>
+                <td> Estimated completion date and time. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
@@ -4448,10 +4893,52 @@ Manage jobs for PowerStore
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=3 > estimated_completion_time </td>
+                <td colspan=3 > parent_id </td>
                 <td> str </td>
                 <td>success</td>
-                <td> Estimated completion date and time. </td>
+                <td> Unique identifier of the parent job, if applicable. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=3 > phase </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Current status of the job. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=3 > progress_percentage </td>
+                <td> int </td>
+                <td>success</td>
+                <td> Percent complete of the job. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=3 > resource_action </td>
+                <td> str </td>
+                <td>success</td>
+                <td> User-specified action to be performed on the given resource. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=3 > resource_id </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Unique identifier of the resource on which the job is operating. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=3 > resource_name </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Name of the resource on which the job is operating. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=3 > resource_type </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Resource Type for the given resource. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
@@ -4472,19 +4959,10 @@ Manage jobs for PowerStore
                         <td class="elbow-placeholder">&nbsp;</td>
                         <td class="elbow-placeholder">&nbsp;</td>
                         <td class="elbow-placeholder">&nbsp;</td>
-                        <td colspan=1 > severity </td>
-                        <td> str </td>
+                        <td colspan=1 > arguments </td>
+                        <td> list </td>
                         <td>success</td>
-                        <td> Type of the severity. </td>
-                    </tr>
-                                    <tr>
-                        <td class="elbow-placeholder">&nbsp;</td>
-                        <td class="elbow-placeholder">&nbsp;</td>
-                        <td class="elbow-placeholder">&nbsp;</td>
-                        <td colspan=1 > message_l10n </td>
-                        <td> str </td>
-                        <td>success</td>
-                        <td> The description of the error. </td>
+                        <td> Values involved in the error. </td>
                     </tr>
                                     <tr>
                         <td class="elbow-placeholder">&nbsp;</td>
@@ -4499,10 +4977,19 @@ Manage jobs for PowerStore
                         <td class="elbow-placeholder">&nbsp;</td>
                         <td class="elbow-placeholder">&nbsp;</td>
                         <td class="elbow-placeholder">&nbsp;</td>
-                        <td colspan=1 > arguments </td>
-                        <td> list </td>
+                        <td colspan=1 > message_l10n </td>
+                        <td> str </td>
                         <td>success</td>
-                        <td> Values involved in the error. </td>
+                        <td> The description of the error. </td>
+                    </tr>
+                                    <tr>
+                        <td class="elbow-placeholder">&nbsp;</td>
+                        <td class="elbow-placeholder">&nbsp;</td>
+                        <td class="elbow-placeholder">&nbsp;</td>
+                        <td colspan=1 > severity </td>
+                        <td> str </td>
+                        <td>success</td>
+                        <td> Type of the severity. </td>
                     </tr>
                                                              <tr>
                     <td class="elbow-placeholder">&nbsp;</td>
@@ -4514,17 +5001,24 @@ Manage jobs for PowerStore
                 </tr>
                                                             <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=3 > user </td>
+                <td colspan=3 > response_status </td>
                 <td> str </td>
                 <td>success</td>
-                <td> Name of the user associated with the job. </td>
+                <td> Possible HTTP status values of completed or failed jobs. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=3 > progress_percentage </td>
-                <td> int </td>
+                <td colspan=3 > root_id </td>
+                <td> str </td>
                 <td>success</td>
-                <td> Percent complete of the job. </td>
+                <td> Unique identifier of the root job, if applicable. The root job is the job at the top of the parent hierarchy. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=3 > start_time </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Date and time when the job execution started. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
@@ -4535,40 +5029,19 @@ Manage jobs for PowerStore
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=3 > end_time </td>
-                <td> str </td>
+                <td colspan=3 > step_order </td>
+                <td> int </td>
                 <td>success</td>
-                <td> Date and time when the job execution completed. </td>
+                <td> Order of a given job step with respect to its siblings within the job hierarchy. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=3 > phase </td>
+                <td colspan=3 > user </td>
                 <td> str </td>
                 <td>success</td>
-                <td> Current status of the job. </td>
+                <td> Name of the user associated with the job. </td>
             </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=3 > description_l10n </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Description of the job. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=3 > resource_type </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Resource Type for the given resource. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=3 > resource_id </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Unique identifier of the resource on which the job is operating. </td>
-            </tr>
-                                                                                                </table>
+                                        </table>
 
 ### Authors
 * Akash Shendge (@shenda1) <ansible.team@dell.com>
@@ -4592,13 +5065,13 @@ Manage LDAP Account for PowerStore
         <th>Choices</th>
         <th width="80%">Description</th>
     </tr>
-                    <tr>
-            <td colspan=1 > role_id</td>
+                                                            <tr>
+            <td colspan=1 > ldap_account_id</td>
             <td> int  </td>
             <td></td>
             <td></td>
             <td></td>
-            <td> <br> Unique identifier of the role to which the new LDAP account will be mapped. </td>
+            <td> <br> Unique identifier of the LDAP account. </td>
         </tr>
                     <tr>
             <td colspan=1 > ldap_account_name</td>
@@ -4609,12 +5082,12 @@ Manage LDAP Account for PowerStore
             <td> <br> Name of the new LDAP account to be created.  <br> This has to match to the LDAP user or group in LDAP server to which the LDAP account is mapped. </td>
         </tr>
                     <tr>
-            <td colspan=1 > port</td>
+            <td colspan=1 > ldap_domain_id</td>
             <td> int  </td>
             <td></td>
             <td></td>
             <td></td>
-            <td> <br> Port number for the PowerStore array.  <br> If not passed, it will take 443 as default. </td>
+            <td> <br> Unique identifier of the LDAP domain to which LDAP user or group belongs. </td>
         </tr>
                     <tr>
             <td colspan=1 > ldap_domain_name</td>
@@ -4625,36 +5098,12 @@ Manage LDAP Account for PowerStore
             <td> <br> Name of the LDAP domain to which LDAP user or group belongs. </td>
         </tr>
                     <tr>
-            <td colspan=1 > timeout</td>
-            <td> int  </td>
-            <td></td>
-            <td> 120 </td>
-            <td></td>
-            <td> <br> Time after which the connection will get terminated.  <br> It is to be mentioned in seconds. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > ldap_account_type</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td> <ul> <li>User</li>  <li>Group</li> </ul></td>
-            <td> <br> Type of LDAP account. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > user</td>
-            <td> str  </td>
-            <td> True </td>
-            <td></td>
-            <td></td>
-            <td> <br> The username of the PowerStore host. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > ldap_account_id</td>
+            <td colspan=1 > role_id</td>
             <td> int  </td>
             <td></td>
             <td></td>
             <td></td>
-            <td> <br> Unique identifier of the LDAP account. </td>
+            <td> <br> Unique identifier of the role to which the new LDAP account will be mapped. </td>
         </tr>
                     <tr>
             <td colspan=1 > role_name</td>
@@ -4665,12 +5114,28 @@ Manage LDAP Account for PowerStore
             <td> <br> Name of the role to which the new LDAP account will be mapped. </td>
         </tr>
                     <tr>
+            <td colspan=1 > ldap_account_type</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td> <ul> <li>User</li>  <li>Group</li> </ul></td>
+            <td> <br> Type of LDAP account. </td>
+        </tr>
+                    <tr>
             <td colspan=1 > state</td>
             <td> str  </td>
             <td> True </td>
             <td></td>
             <td> <ul> <li>absent</li>  <li>present</li> </ul></td>
             <td> <br> Define whether the LDAP account should exist or not.  <br> For Delete operation only, it should be set to "absent".  <br> For all other operations except delete, it should be set to "present". </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > array_ip</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td></td>
+            <td> <br> IP or FQDN of the PowerStore management system. </td>
         </tr>
                     <tr>
             <td colspan=1 > verifycert</td>
@@ -4681,6 +5146,14 @@ Manage LDAP Account for PowerStore
             <td> <br> Boolean variable to specify whether to validate SSL certificate or not.  <br> True - indicates that the SSL certificate should be verified. Set the environment variable REQUESTS_CA_BUNDLE to the path of the SSL certificate.  <br> False - indicates that the SSL certificate should not be verified. </td>
         </tr>
                     <tr>
+            <td colspan=1 > user</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td></td>
+            <td> <br> The username of the PowerStore host. </td>
+        </tr>
+                    <tr>
             <td colspan=1 > password</td>
             <td> str  </td>
             <td> True </td>
@@ -4689,22 +5162,22 @@ Manage LDAP Account for PowerStore
             <td> <br> The password of the PowerStore host. </td>
         </tr>
                     <tr>
-            <td colspan=1 > ldap_domain_id</td>
+            <td colspan=1 > timeout</td>
+            <td> int  </td>
+            <td></td>
+            <td> 120 </td>
+            <td></td>
+            <td> <br> Time after which the connection will get terminated.  <br> It is to be mentioned in seconds. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > port</td>
             <td> int  </td>
             <td></td>
             <td></td>
             <td></td>
-            <td> <br> Unique identifier of the LDAP domain to which LDAP user or group belongs. </td>
+            <td> <br> Port number for the PowerStore array.  <br> If not passed, it will take 443 as default. </td>
         </tr>
-                    <tr>
-            <td colspan=1 > array_ip</td>
-            <td> str  </td>
-            <td> True </td>
-            <td></td>
-            <td></td>
-            <td> <br> IP or FQDN of the PowerStore management system. </td>
-        </tr>
-                                                                                            </table>
+                                                    </table>
 
 ### Notes
 * The check_mode is supported.
@@ -4771,7 +5244,7 @@ Manage LDAP Account for PowerStore
         <th>Returned</th>
         <th width="100%">Description</th>
     </tr>
-                                    <tr>
+                                                                                            <tr>
             <td colspan=2 > changed </td>
             <td>  bool </td>
             <td> always </td>
@@ -4785,10 +5258,10 @@ Manage LDAP Account for PowerStore
         </tr>
                             <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > name </td>
+                <td colspan=1 > dn </td>
                 <td> str </td>
                 <td>success</td>
-                <td> Name of the LDAP account. </td>
+                <td> Types of directory service protocol. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
@@ -4799,17 +5272,24 @@ Manage LDAP Account for PowerStore
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > role_id </td>
-                <td> int </td>
-                <td>success</td>
-                <td> Unique identifier of the role to which the LDAP account is mapped. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=1 > id </td>
                 <td> int </td>
                 <td>success</td>
                 <td> Unique identifier of the LDAP account. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > name </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Name of the LDAP account. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > role_id </td>
+                <td> int </td>
+                <td>success</td>
+                <td> Unique identifier of the role to which the LDAP account is mapped. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
@@ -4818,14 +5298,7 @@ Manage LDAP Account for PowerStore
                 <td>success</td>
                 <td> Type of LDAP account. </td>
             </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > dn </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Types of directory service protocol. </td>
-            </tr>
-                                                                                                </table>
+                                        </table>
 
 ### Authors
 * Trisha Datta (@Trisha_Datta) <ansible.team@dell.com>
@@ -4839,7 +5312,7 @@ Manage LDAP domain for PowerStore
  Managing LDAP domain on PowerStore Storage System includes creating LDAP domain, getting details of LDAP domain, modifying LDAP domain, verifying LDAP domain and deleting LDAP domain.
 
 ### Parameters
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
 <table>
     <tr>
         <th colspan=2>Parameter</th>
@@ -4849,13 +5322,93 @@ Manage LDAP domain for PowerStore
         <th>Choices</th>
         <th width="80%">Description</th>
     </tr>
+                                                            <tr>
+            <td colspan=2 > ldap_domain_name</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Name of the LDAP authority to construct the LDAP server configuration.  <br> Mandatory for the create operation. </td>
+        </tr>
                     <tr>
-            <td colspan=2 > timeout</td>
+            <td colspan=2 > ldap_domain_id</td>
             <td> int  </td>
             <td></td>
-            <td> 120 </td>
             <td></td>
-            <td> <br> Time after which the connection will get terminated.  <br> It is to be mentioned in seconds. </td>
+            <td></td>
+            <td> <br> Unique identifier of the LDAP domain configuration. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > ldap_servers</td>
+            <td> list   <br> elements: str </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> List of IP addresses of the LDAP servers for the domain. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > ldap_server_state</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td> <ul> <li>present-in-domain</li>  <li>absent-in-domain</li> </ul></td>
+            <td> <br> State of the LDAP server.  <br> The ldap_servers and ldap_server_state are required together. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > ldap_server_port</td>
+            <td> int  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Port number used to connect to the LDAP Server. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > protocol</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td> <ul> <li>LDAP</li>  <li>LDAPS</li> </ul></td>
+            <td> <br> Types of directory service protocol. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > ldap_server_type</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td> <ul> <li>AD</li>  <li>OpenLDAP</li> </ul></td>
+            <td> <br> Types of the LDAP server. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > bind_user</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Distinguished Name (DN) of the user to be used when binding; that is, authenticating and setting up the connection to the LDAP server.  <br> Mandatory for the create operation. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > bind_password</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Password to use when binding a new LDAP session.  <br> Mandatory for the create operation. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > ldap_timeout</td>
+            <td> int  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Timeout for establishing a connection to an LDAP server. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > is_global_catalog</td>
+            <td> bool  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Whether or not the catalog is global. </td>
         </tr>
                     <tr>
             <td colspan=2 > ldap_domain_user_settings</td>
@@ -4874,7 +5427,7 @@ Manage LDAP domain for PowerStore
                 <td></td>
                 <td>  <br> Name of the LDAP attribute whose value indicates the unique identifier of the user.  <br> Default value is sAMAccountName.  </td>
             </tr>
-                    <tr>
+                                <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=1 > user_object_class </td>
                 <td> str  </td>
@@ -4883,7 +5436,7 @@ Manage LDAP domain for PowerStore
                 <td></td>
                 <td>  <br> LDAP object class for users.  <br> Default value is user.  </td>
             </tr>
-                    <tr>
+                                <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=1 > user_search_path </td>
                 <td> str  </td>
@@ -4892,55 +5445,7 @@ Manage LDAP domain for PowerStore
                 <td></td>
                 <td>  <br> Path used to search for users on the directory server.  <br> Search path is empty, if global catalog is enabled.  </td>
             </tr>
-                            <tr>
-            <td colspan=2 > ldap_server_type</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td> <ul> <li>AD</li>  <li>OpenLDAP</li> </ul></td>
-            <td> <br> Types of the LDAP server. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > ldap_server_port</td>
-            <td> int  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Port number used to connect to the LDAP Server. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > user</td>
-            <td> str  </td>
-            <td> True </td>
-            <td></td>
-            <td></td>
-            <td> <br> The username of the PowerStore host. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > port</td>
-            <td> int  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Port number for the PowerStore array.  <br> If not passed, it will take 443 as default. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > ldap_servers</td>
-            <td> list   <br> elements: str </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> List of IP addresses of the LDAP servers for the domain. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > ldap_domain_name</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Name of the LDAP authority to construct the LDAP server configuration.  <br> Mandatory for the create operation. </td>
-        </tr>
-                    <tr>
+                                        <tr>
             <td colspan=2 > ldap_domain_group_settings</td>
             <td> dict  </td>
             <td></td>
@@ -4950,23 +5455,14 @@ Manage LDAP domain for PowerStore
         </tr>
                             <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > group_search_level </td>
-                <td> int  </td>
-                <td></td>
-                <td></td>
-                <td></td>
-                <td>  <br> Nested search level for performing group search.  <br> Default value is 0.  </td>
-            </tr>
-                    <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > group_object_class </td>
+                <td colspan=1 > group_name_attribute </td>
                 <td> str  </td>
                 <td></td>
                 <td></td>
                 <td></td>
-                <td>  <br> LDAP object class for groups.  <br> Default value is group.  </td>
+                <td>  <br> Name of the LDAP attribute whose value indicates the group name.  <br> Default value is cn.  </td>
             </tr>
-                    <tr>
+                                <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=1 > group_member_attribute </td>
                 <td> str  </td>
@@ -4975,7 +5471,16 @@ Manage LDAP domain for PowerStore
                 <td></td>
                 <td>  <br> Name of the LDAP attribute whose value contains the names of group members within a group.  <br> Default value is member.  </td>
             </tr>
-                    <tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > group_object_class </td>
+                <td> str  </td>
+                <td></td>
+                <td></td>
+                <td></td>
+                <td>  <br> LDAP object class for groups.  <br> Default value is group.  </td>
+            </tr>
+                                <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=1 > group_search_path </td>
                 <td> str  </td>
@@ -4984,70 +5489,22 @@ Manage LDAP domain for PowerStore
                 <td></td>
                 <td>  <br> Path used to search for groups on the directory server.  <br> Search path is empty, if global catalog is enabled.  </td>
             </tr>
-                    <tr>
+                                <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > group_name_attribute </td>
-                <td> str  </td>
+                <td colspan=1 > group_search_level </td>
+                <td> int  </td>
                 <td></td>
                 <td></td>
                 <td></td>
-                <td>  <br> Name of the LDAP attribute whose value indicates the group name.  <br> Default value is cn.  </td>
+                <td>  <br> Nested search level for performing group search.  <br> Default value is 0.  </td>
             </tr>
-                            <tr>
-            <td colspan=2 > ldap_timeout</td>
-            <td> int  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Timeout for establishing a connection to an LDAP server. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > is_global_catalog</td>
-            <td> bool  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Whether or not the catalog is global. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > bind_password</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Password to use when binding a new LDAP session.  <br> Mandatory for the create operation. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > array_ip</td>
-            <td> str  </td>
-            <td> True </td>
-            <td></td>
-            <td></td>
-            <td> <br> IP or FQDN of the PowerStore management system. </td>
-        </tr>
-                    <tr>
+                                        <tr>
             <td colspan=2 > verify_configuration</td>
             <td> bool  </td>
             <td></td>
             <td> False </td>
             <td></td>
             <td> <br> Indicates whether to perform the verify LDAP domain configuration or not. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > verifycert</td>
-            <td> bool  </td>
-            <td> True </td>
-            <td></td>
-            <td> <ul> <li>True</li>  <li>False</li> </ul></td>
-            <td> <br> Boolean variable to specify whether to validate SSL certificate or not.  <br> True - indicates that the SSL certificate should be verified. Set the environment variable REQUESTS_CA_BUNDLE to the path of the SSL certificate.  <br> False - indicates that the SSL certificate should not be verified. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > ldap_server_state</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td> <ul> <li>present-in-domain</li>  <li>absent-in-domain</li> </ul></td>
-            <td> <br> State of the LDAP server.  <br> The ldap_servers and ldap_server_state are required together. </td>
         </tr>
                     <tr>
             <td colspan=2 > state</td>
@@ -5058,6 +5515,30 @@ Manage LDAP domain for PowerStore
             <td> <br> Define whether the LDAP domain configuration should exist or not.  <br> For Delete operation only, it should be set to "absent".  <br> For all other operations except delete, it should be set to "present". </td>
         </tr>
                     <tr>
+            <td colspan=2 > array_ip</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td></td>
+            <td> <br> IP or FQDN of the PowerStore management system. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > verifycert</td>
+            <td> bool  </td>
+            <td> True </td>
+            <td></td>
+            <td> <ul> <li>True</li>  <li>False</li> </ul></td>
+            <td> <br> Boolean variable to specify whether to validate SSL certificate or not.  <br> True - indicates that the SSL certificate should be verified. Set the environment variable REQUESTS_CA_BUNDLE to the path of the SSL certificate.  <br> False - indicates that the SSL certificate should not be verified. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > user</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td></td>
+            <td> <br> The username of the PowerStore host. </td>
+        </tr>
+                    <tr>
             <td colspan=2 > password</td>
             <td> str  </td>
             <td> True </td>
@@ -5066,30 +5547,22 @@ Manage LDAP domain for PowerStore
             <td> <br> The password of the PowerStore host. </td>
         </tr>
                     <tr>
-            <td colspan=2 > ldap_domain_id</td>
+            <td colspan=2 > timeout</td>
+            <td> int  </td>
+            <td></td>
+            <td> 120 </td>
+            <td></td>
+            <td> <br> Time after which the connection will get terminated.  <br> It is to be mentioned in seconds. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > port</td>
             <td> int  </td>
             <td></td>
             <td></td>
             <td></td>
-            <td> <br> Unique identifier of the LDAP domain configuration. </td>
+            <td> <br> Port number for the PowerStore array.  <br> If not passed, it will take 443 as default. </td>
         </tr>
-                    <tr>
-            <td colspan=2 > bind_user</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Distinguished Name (DN) of the user to be used when binding; that is, authenticating and setting up the connection to the LDAP server.  <br> Mandatory for the create operation. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > protocol</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td> <ul> <li>LDAP</li>  <li>LDAPS</li> </ul></td>
-            <td> <br> Types of directory service protocol. </td>
-        </tr>
-                                                                                            </table>
+                                                    </table>
 
 ### Notes
 * The 'is_global_catalog' option can be enabled only for AD server type.
@@ -5206,7 +5679,13 @@ Manage LDAP domain for PowerStore
         <th>Returned</th>
         <th width="100%">Description</th>
     </tr>
-                                    <tr>
+                                                                                            <tr>
+            <td colspan=2 > changed </td>
+            <td>  bool </td>
+            <td> always </td>
+            <td> Whether or not the resource has changed. </td>
+        </tr>
+                    <tr>
             <td colspan=2 > ldap_domain_details </td>
             <td>  complex </td>
             <td> When LDAP domain configuration exists. </td>
@@ -5214,122 +5693,10 @@ Manage LDAP domain for PowerStore
         </tr>
                             <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > id </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Unique identifier of the new LDAP server configuration. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > protocol </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Types of directory service protocol. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > ldap_server_type </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Types of LDAP server. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > port </td>
-                <td> int </td>
-                <td>success</td>
-                <td> Port number used to connect to the LDAP server(s). </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > ldap_servers </td>
-                <td> list </td>
-                <td>success</td>
-                <td> List of IP addresses of the LDAP servers for the domain. IP addresses are in IPv4 format. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > ldap_server_type_l10n </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Localized message string corresponding to ldap_server_type. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > protocol_l10n </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Localized message string corresponding to protocol. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > ldap_timeout </td>
-                <td> int </td>
-                <td>success</td>
-                <td> Timeout for establishing a connection to an LDAP server. Default value is 30000 (30 seconds). </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > is_global_catalog </td>
-                <td> bool </td>
-                <td>success</td>
-                <td> Whether or not the catalog is global. Default value is false. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=1 > bind_user </td>
                 <td> str </td>
                 <td>success</td>
                 <td> Distinguished Name (DN) of the user to be used when binding. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > group_object_class </td>
-                <td> str </td>
-                <td>success</td>
-                <td> LDAP object class for groups. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > group_name_attribute </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Name of the LDAP attribute whose value indicates the group name. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > group_member_attribute </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Name of the LDAP attribute whose value contains the names of group members within a group. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > group_search_path </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Path used to search for groups on the directory server. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > group_search_level </td>
-                <td> int </td>
-                <td>success</td>
-                <td> Nested search level for performing group search. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > user_object_class </td>
-                <td> str </td>
-                <td>success</td>
-                <td> LDAP object class for users. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > user_id_attribute </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Name of the LDAP attribute whose value indicates the unique identifier of the user. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
@@ -5340,18 +5707,124 @@ Manage LDAP domain for PowerStore
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > group_member_attribute </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Name of the LDAP attribute whose value contains the names of group members within a group. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > group_name_attribute </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Name of the LDAP attribute whose value indicates the group name. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > group_object_class </td>
+                <td> str </td>
+                <td>success</td>
+                <td> LDAP object class for groups. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > group_search_level </td>
+                <td> int </td>
+                <td>success</td>
+                <td> Nested search level for performing group search. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > group_search_path </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Path used to search for groups on the directory server. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > id </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Unique identifier of the new LDAP server configuration. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > is_global_catalog </td>
+                <td> bool </td>
+                <td>success</td>
+                <td> Whether or not the catalog is global. Default value is false. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > ldap_server_type </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Types of LDAP server. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > ldap_server_type_l10n </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Localized message string corresponding to ldap_server_type. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > ldap_servers </td>
+                <td> list </td>
+                <td>success</td>
+                <td> List of IP addresses of the LDAP servers for the domain. IP addresses are in IPv4 format. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > ldap_timeout </td>
+                <td> int </td>
+                <td>success</td>
+                <td> Timeout for establishing a connection to an LDAP server. Default value is 30000 (30 seconds). </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > port </td>
+                <td> int </td>
+                <td>success</td>
+                <td> Port number used to connect to the LDAP server(s). </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > protocol </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Types of directory service protocol. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > protocol_l10n </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Localized message string corresponding to protocol. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > user_id_attribute </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Name of the LDAP attribute whose value indicates the unique identifier of the user. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > user_object_class </td>
+                <td> str </td>
+                <td>success</td>
+                <td> LDAP object class for users. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=1 > user_search_path </td>
                 <td> str </td>
                 <td>success</td>
                 <td> Path used to search for users on the directory server. </td>
             </tr>
-                                        <tr>
-            <td colspan=2 > changed </td>
-            <td>  bool </td>
-            <td> always </td>
-            <td> Whether or not the resource has changed. </td>
-        </tr>
-                                                                            </table>
+                                        </table>
 
 ### Authors
 * Akash Shendge (@shenda1) <ansible.team@dell.com>
@@ -5375,37 +5848,13 @@ Local user operations for PowerStore Storage System
         <th>Choices</th>
         <th width="80%">Description</th>
     </tr>
-                    <tr>
-            <td colspan=1 > role_id</td>
-            <td> int  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> The unique identifier of the role to which the local user account will be mapped.  <br> It is mutually exclusive with role_name. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > new_password</td>
+                                                            <tr>
+            <td colspan=1 > user_name</td>
             <td> str  </td>
             <td></td>
             <td></td>
             <td></td>
-            <td> <br> New password for the existing local user account. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > state</td>
-            <td> str  </td>
-            <td> True </td>
-            <td></td>
-            <td> <ul> <li>absent</li>  <li>present</li> </ul></td>
-            <td> <br> Define whether the local user should exist or not. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > port</td>
-            <td> int  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Port number for the PowerStore array.  <br> If not passed, it will take 443 as default. </td>
+            <td> <br> Name of the local user account. Mutually exclusive with user_id.  <br> Mandatory only for create operation. </td>
         </tr>
                     <tr>
             <td colspan=1 > user_id</td>
@@ -5416,22 +5865,6 @@ Local user operations for PowerStore Storage System
             <td> <br> Unique identifier of the local user account.  <br> Mutually exclusive with user_name. </td>
         </tr>
                     <tr>
-            <td colspan=1 > user_name</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Name of the local user account. Mutually exclusive with user_id.  <br> Mandatory only for create operation. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > timeout</td>
-            <td> int  </td>
-            <td></td>
-            <td> 120 </td>
-            <td></td>
-            <td> <br> Time after which the connection will get terminated.  <br> It is to be mentioned in seconds. </td>
-        </tr>
-                    <tr>
             <td colspan=1 > user_password</td>
             <td> str  </td>
             <td></td>
@@ -5440,12 +5873,44 @@ Local user operations for PowerStore Storage System
             <td> <br> Password for the new local user account to be created.  <br> Mandatory only for create operation. </td>
         </tr>
                     <tr>
+            <td colspan=1 > new_password</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> New password for the existing local user account. </td>
+        </tr>
+                    <tr>
             <td colspan=1 > role_name</td>
             <td> str  </td>
             <td></td>
             <td></td>
             <td></td>
             <td> <br> The name of the role to which the local user account will be mapped.  <br> It is mutually exclusive with role_id. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > role_id</td>
+            <td> int  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> The unique identifier of the role to which the local user account will be mapped.  <br> It is mutually exclusive with role_name. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > is_locked</td>
+            <td> bool  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Whether the user account is locked or not.  <br> Defaults to false at creation time. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > state</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td> <ul> <li>absent</li>  <li>present</li> </ul></td>
+            <td> <br> Define whether the local user should exist or not. </td>
         </tr>
                     <tr>
             <td colspan=1 > array_ip</td>
@@ -5464,6 +5929,14 @@ Local user operations for PowerStore Storage System
             <td> <br> Boolean variable to specify whether to validate SSL certificate or not.  <br> True - indicates that the SSL certificate should be verified. Set the environment variable REQUESTS_CA_BUNDLE to the path of the SSL certificate.  <br> False - indicates that the SSL certificate should not be verified. </td>
         </tr>
                     <tr>
+            <td colspan=1 > user</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td></td>
+            <td> <br> The username of the PowerStore host. </td>
+        </tr>
+                    <tr>
             <td colspan=1 > password</td>
             <td> str  </td>
             <td> True </td>
@@ -5472,22 +5945,22 @@ Local user operations for PowerStore Storage System
             <td> <br> The password of the PowerStore host. </td>
         </tr>
                     <tr>
-            <td colspan=1 > is_locked</td>
-            <td> bool  </td>
+            <td colspan=1 > timeout</td>
+            <td> int  </td>
             <td></td>
+            <td> 120 </td>
             <td></td>
-            <td></td>
-            <td> <br> Whether the user account is locked or not.  <br> Defaults to false at creation time. </td>
+            <td> <br> Time after which the connection will get terminated.  <br> It is to be mentioned in seconds. </td>
         </tr>
                     <tr>
-            <td colspan=1 > user</td>
-            <td> str  </td>
-            <td> True </td>
+            <td colspan=1 > port</td>
+            <td> int  </td>
             <td></td>
             <td></td>
-            <td> <br> The username of the PowerStore host. </td>
+            <td></td>
+            <td> <br> Port number for the PowerStore array.  <br> If not passed, it will take 443 as default. </td>
         </tr>
-                                                                                            </table>
+                                                    </table>
 
 ### Notes
 * The check_mode is not supported.
@@ -5557,13 +6030,47 @@ Local user operations for PowerStore Storage System
         <th>Returned</th>
         <th width="100%">Description</th>
     </tr>
-                                    <tr>
+                                                                                            <tr>
+            <td colspan=2 > changed </td>
+            <td>  bool </td>
+            <td> always </td>
+            <td> Whether or not the resource has changed. </td>
+        </tr>
+                    <tr>
             <td colspan=2 > local_user_details </td>
             <td>  complex </td>
             <td> When local user exists </td>
             <td> Details of the local user. </td>
         </tr>
                             <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > id </td>
+                <td> str </td>
+                <td>success</td>
+                <td> The system generated ID given to the local user. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > is_built_in </td>
+                <td> bool </td>
+                <td>success</td>
+                <td> Whether the user account is built-in or not. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > is_default_password </td>
+                <td> bool </td>
+                <td>success</td>
+                <td> Whether the user account has a default password or not. Only applies to default user accounts </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > is_locked </td>
+                <td> bool </td>
+                <td>success</td>
+                <td> Whether the user account is locked or not. Defaults to false at creation time. </td>
+            </tr>
+                                <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=1 > name </td>
                 <td> str </td>
@@ -5579,46 +6086,12 @@ Local user operations for PowerStore Storage System
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > id </td>
-                <td> str </td>
-                <td>success</td>
-                <td> The system generated ID given to the local user. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > is_default_password </td>
-                <td> bool </td>
-                <td>success</td>
-                <td> Whether the user account has a default password or not. Only applies to default user accounts </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=1 > role_name </td>
                 <td> str </td>
                 <td>success</td>
                 <td> Name of the role to which local user account is mapped. </td>
             </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > is_built_in </td>
-                <td> bool </td>
-                <td>success</td>
-                <td> Whether the user account is built-in or not. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > is_locked </td>
-                <td> bool </td>
-                <td>success</td>
-                <td> Whether the user account is locked or not. Defaults to false at creation time. </td>
-            </tr>
-                                        <tr>
-            <td colspan=2 > changed </td>
-            <td>  bool </td>
-            <td> always </td>
-            <td> Whether or not the resource has changed. </td>
-        </tr>
-                                                                            </table>
+                                        </table>
 
 ### Authors
 * Arindam Datta (@dattaarindam) <ansible.team@dell.com>
@@ -5632,7 +6105,7 @@ NAS Server operations for PowerStore Storage system
  Supports getting the details and modifying the attributes of a NAS server.
 
 ### Parameters
-                                                                                                                                                                                                                                                                                                                                                                                
+                                                                                                                                                                                                                                                                                                                                                                                                    
 <table>
     <tr>
         <th colspan=1>Parameter</th>
@@ -5642,6 +6115,62 @@ NAS Server operations for PowerStore Storage system
         <th>Choices</th>
         <th width="80%">Description</th>
     </tr>
+                                                            <tr>
+            <td colspan=1 > nas_server_name</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Name of the NAS server. Mutually exclusive with nas_server_id. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > nas_server_id</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Unique id of the NAS server. Mutually exclusive with nas_server_name. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > description</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Description of the NAS server. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > nas_server_new_name</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> New name of the NAS server for a rename operation. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > current_node</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Unique identifier or name of the node on which the NAS server is running. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > preferred_node</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Unique identifier or name of the preferred node for the NAS server. The initial value (on NAS server create) is taken from the current node. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > current_unix_directory_service</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td> <ul> <li>NIS</li>  <li>LDAP</li>  <li>LOCAL_FILES</li>  <li>LOCAL_THEN_NIS</li>  <li>LOCAL_THEN_LDAP</li> </ul></td>
+            <td> <br> Define the Unix directory service used for looking up identity information for Unix such as UIDs, GIDs, net groups, and so on. </td>
+        </tr>
                     <tr>
             <td colspan=1 > default_unix_user</td>
             <td> str  </td>
@@ -5659,68 +6188,20 @@ NAS Server operations for PowerStore Storage system
             <td> <br> Default Windows user name used for granting access in case of Unix to Windows user mapping failure. When empty, access in such case is denied. </td>
         </tr>
                     <tr>
+            <td colspan=1 > protection_policy</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Name/ID of the protection policy applied to the nas server.  <br> Policy can be removed by passing an empty string in the protection_policy parameter. </td>
+        </tr>
+                    <tr>
             <td colspan=1 > state</td>
             <td> str  </td>
             <td> True </td>
             <td></td>
             <td> <ul> <li>absent</li>  <li>present</li> </ul></td>
             <td> <br> Define whether the nas server should exist or not. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > nas_server_new_name</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> New name of the NAS server for a rename operation. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > port</td>
-            <td> int  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Port number for the PowerStore array.  <br> If not passed, it will take 443 as default. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > current_node</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Unique identifier or name of the node on which the NAS server is running. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > current_unix_directory_service</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td> <ul> <li>NIS</li>  <li>LDAP</li>  <li>LOCAL_FILES</li>  <li>LOCAL_THEN_NIS</li>  <li>LOCAL_THEN_LDAP</li> </ul></td>
-            <td> <br> Define the Unix directory service used for looking up identity information for Unix such as UIDs, GIDs, net groups, and so on. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > timeout</td>
-            <td> int  </td>
-            <td></td>
-            <td> 120 </td>
-            <td></td>
-            <td> <br> Time after which the connection will get terminated.  <br> It is to be mentioned in seconds. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > preferred_node</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Unique identifier or name of the preferred node for the NAS server. The initial value (on NAS server create) is taken from the current node. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > user</td>
-            <td> str  </td>
-            <td> True </td>
-            <td></td>
-            <td></td>
-            <td> <br> The username of the PowerStore host. </td>
         </tr>
                     <tr>
             <td colspan=1 > array_ip</td>
@@ -5731,14 +6212,6 @@ NAS Server operations for PowerStore Storage system
             <td> <br> IP or FQDN of the PowerStore management system. </td>
         </tr>
                     <tr>
-            <td colspan=1 > nas_server_name</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Name of the NAS server. Mutually exclusive with nas_server_id. </td>
-        </tr>
-                    <tr>
             <td colspan=1 > verifycert</td>
             <td> bool  </td>
             <td> True </td>
@@ -5747,12 +6220,12 @@ NAS Server operations for PowerStore Storage system
             <td> <br> Boolean variable to specify whether to validate SSL certificate or not.  <br> True - indicates that the SSL certificate should be verified. Set the environment variable REQUESTS_CA_BUNDLE to the path of the SSL certificate.  <br> False - indicates that the SSL certificate should not be verified. </td>
         </tr>
                     <tr>
-            <td colspan=1 > nas_server_id</td>
+            <td colspan=1 > user</td>
             <td> str  </td>
+            <td> True </td>
             <td></td>
             <td></td>
-            <td></td>
-            <td> <br> Unique id of the NAS server. Mutually exclusive with nas_server_name. </td>
+            <td> <br> The username of the PowerStore host. </td>
         </tr>
                     <tr>
             <td colspan=1 > password</td>
@@ -5763,17 +6236,26 @@ NAS Server operations for PowerStore Storage system
             <td> <br> The password of the PowerStore host. </td>
         </tr>
                     <tr>
-            <td colspan=1 > description</td>
-            <td> str  </td>
+            <td colspan=1 > timeout</td>
+            <td> int  </td>
             <td></td>
+            <td> 120 </td>
             <td></td>
-            <td></td>
-            <td> <br> Description of the NAS server. </td>
+            <td> <br> Time after which the connection will get terminated.  <br> It is to be mentioned in seconds. </td>
         </tr>
-                                                                                            </table>
+                    <tr>
+            <td colspan=1 > port</td>
+            <td> int  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Port number for the PowerStore array.  <br> If not passed, it will take 443 as default. </td>
+        </tr>
+                                                    </table>
 
 ### Notes
 * The check_mode is not supported.
+* Adding/Removing protection policy to/from a NAS server is supported for PowerStore version 3.0.0 and above.
 * The modules present in this collection named as 'dellemc.powerstore' are built to support the Dell PowerStore storage platform.
 
 ### Examples
@@ -5816,11 +6298,22 @@ NAS Server operations for PowerStore Storage system
      current_unix_directory_service: "LOCAL_FILES"
      current_node: "{{cur_node_n1}}"
      preferred_node: "{{prefered_node}}"
+     protection_policy: "protection_policy_1"
+     state: "present"
+
+ - name: Remove protection policy
+   dellemc.powerstore.nasserver:
+     array_ip: "{{array_ip}}"
+     verifycert: "{{verifycert}}"
+     user: "{{user}}"
+     password: "{{password}}"
+     nas_server_id: "{{nas_id}}"
+     protection_policy: ""
      state: "present"
 ```
 
 ### Return Values
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
 <table>
     <tr>
         <th colspan=2>Key</th>
@@ -5828,7 +6321,7 @@ NAS Server operations for PowerStore Storage system
         <th>Returned</th>
         <th width="100%">Description</th>
     </tr>
-                                    <tr>
+                                                                                            <tr>
             <td colspan=2 > changed </td>
             <td>  bool </td>
             <td> always </td>
@@ -5842,45 +6335,17 @@ NAS Server operations for PowerStore Storage system
         </tr>
                             <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > default_unix_user </td>
+                <td colspan=1 > backup_IPv4_interface_id </td>
                 <td> str </td>
                 <td>success</td>
-                <td> Default Unix user name used for granting access in case of Windows to Unix user mapping failure. </td>
+                <td> Unique identifier of the preferred IPv4 backup interface. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > production_IPv6_interface_id </td>
+                <td colspan=1 > backup_IPv6_interface_id </td>
                 <td> str </td>
                 <td>success</td>
-                <td> Unique identifier of the preferred IPv6 production interface. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > file_interfaces </td>
-                <td> dict </td>
-                <td>success</td>
-                <td> This is the inverse of the resource type file_interface association. Will return the id,name & ip_address of the associated file interface. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > file_systems </td>
-                <td> dict </td>
-                <td>success</td>
-                <td> This is the inverse of the resource type file_system association. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > preferred_node </td>
-                <td> dict </td>
-                <td>success</td>
-                <td> Unique identifier and name of the preferred node for the NAS server. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > is_username_translation_enabled </td>
-                <td> bool </td>
-                <td>success</td>
-                <td> Enable the possibility to match a windows account to a Unix account with different names. </td>
+                <td> Unique identifier of the preferred IPv6 backup interface. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
@@ -5898,24 +6363,38 @@ NAS Server operations for PowerStore Storage system
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > smb_servers </td>
+                <td colspan=1 > default_unix_user </td>
                 <td> str </td>
                 <td>success</td>
-                <td> This is the inverse of the resource type smb_server association. </td>
+                <td> Default Unix user name used for granting access in case of Windows to Unix user mapping failure. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > name </td>
+                <td colspan=1 > description </td>
                 <td> str </td>
                 <td>success</td>
-                <td> Name of the nas server. </td>
+                <td> Additional information about the nas server. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > backup_IPv4_interface_id </td>
+                <td colspan=1 > file_interfaces </td>
+                <td> dict </td>
+                <td>success</td>
+                <td> This is the inverse of the resource type file_interface association. Will return the id,name & ip_address of the associated file interface. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > file_ldaps </td>
                 <td> str </td>
                 <td>success</td>
-                <td> Unique identifier of the preferred IPv4 backup interface. </td>
+                <td> This is the inverse of the resource type file_ldap association. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > file_systems </td>
+                <td> dict </td>
+                <td>success</td>
+                <td> This is the inverse of the resource type file_system association. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
@@ -5923,6 +6402,20 @@ NAS Server operations for PowerStore Storage system
                 <td> str </td>
                 <td>success</td>
                 <td> The system generated ID given to the nas server. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > is_username_translation_enabled </td>
+                <td> bool </td>
+                <td>success</td>
+                <td> Enable the possibility to match a windows account to a Unix account with different names. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > name </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Name of the nas server. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
@@ -5940,24 +6433,10 @@ NAS Server operations for PowerStore Storage system
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > backup_IPv6_interface_id </td>
-                <td> str </td>
+                <td colspan=1 > preferred_node </td>
+                <td> dict </td>
                 <td>success</td>
-                <td> Unique identifier of the preferred IPv6 backup interface. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > file_ldaps </td>
-                <td> str </td>
-                <td>success</td>
-                <td> This is the inverse of the resource type file_ldap association. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > description </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Additional information about the nas server. </td>
+                <td> Unique identifier and name of the preferred node for the NAS server. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
@@ -5966,7 +6445,28 @@ NAS Server operations for PowerStore Storage system
                 <td>success</td>
                 <td> Unique identifier of the preferred IPv4 production interface. </td>
             </tr>
-                                                                                                </table>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > production_IPv6_interface_id </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Unique identifier of the preferred IPv6 production interface. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > protection_policy_id </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Id of the protection policy applied to the nas server. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > smb_servers </td>
+                <td> str </td>
+                <td>success</td>
+                <td> This is the inverse of the resource type smb_server association. </td>
+            </tr>
+                                        </table>
 
 ### Authors
 * Arindam Datta (@dattaarindam) <ansible.team@dell.com>
@@ -5980,7 +6480,7 @@ Manage networks for PowerStore
  Managing networks on PowerStore Storage System includes getting details of network, modifying attributes of network and adding/removing IP ports to/from storage network.
 
 ### Parameters
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                
 <table>
     <tr>
         <th colspan=2>Parameter</th>
@@ -5990,6 +6490,78 @@ Manage networks for PowerStore
         <th>Choices</th>
         <th width="80%">Description</th>
     </tr>
+                                                            <tr>
+            <td colspan=2 > network_name</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> The name of the network.  <br> This parameter is added in 2.0.0.0.  <br> Specify either network_name or network_id for any operation. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > network_id</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> The ID of the network. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > vlan_id</td>
+            <td> int  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> The ID of the VLAN. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > gateway</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Network gateway in IPv4 format. IP version.  <br> Specify empty string to remove the gateway. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > prefix_length</td>
+            <td> int  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Network prefix length. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > new_cluster_mgmt_address</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> New cluster management IP address in IPv4 format. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > storage_discovery_address</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> New storage discovery IP address in IPv4 format.  <br> Specify empty string to remove the storage discovery IP address. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > mtu</td>
+            <td> int  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Maximum Transmission Unit (MTU) packet size set on network interfaces, in bytes. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > new_name</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> New name of the network. </td>
+        </tr>
                     <tr>
             <td colspan=2 > addresses</td>
             <td> list   <br> elements: dict </td>
@@ -6007,7 +6579,7 @@ Manage networks for PowerStore
                 <td></td>
                 <td>  <br> Existing IPv4 address.  </td>
             </tr>
-                    <tr>
+                                <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=1 > new_address </td>
                 <td> str  </td>
@@ -6016,37 +6588,13 @@ Manage networks for PowerStore
                 <td></td>
                 <td>  <br> New IPv4 address.  </td>
             </tr>
-                            <tr>
-            <td colspan=2 > new_cluster_mgmt_address</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> New cluster management IP address in IPv4 format. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > state</td>
-            <td> str  </td>
-            <td> True </td>
-            <td></td>
-            <td> <ul> <li>absent</li>  <li>present</li> </ul></td>
-            <td> <br> Define whether the network exist or not. </td>
-        </tr>
-                    <tr>
+                                        <tr>
             <td colspan=2 > ports</td>
             <td> list   <br> elements: str </td>
             <td></td>
             <td></td>
             <td></td>
             <td> <br> Ports to be mapped/unmapped to/from the storage network. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > port</td>
-            <td> int  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Port number for the PowerStore array.  <br> If not passed, it will take 443 as default. </td>
         </tr>
                     <tr>
             <td colspan=2 > port_state</td>
@@ -6057,6 +6605,32 @@ Manage networks for PowerStore
             <td> <br> Specifies whether port should mapped/unmapped from the storage network. </td>
         </tr>
                     <tr>
+            <td colspan=2 > vasa_provider_credentials</td>
+            <td> dict  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Credentials required for re-registering the VASA vendor provider during the reconfiguration of the cluster management IP address. </td>
+        </tr>
+                            <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > username </td>
+                <td> str  </td>
+                <td> True </td>
+                <td></td>
+                <td></td>
+                <td>  <br> VASA vendor provider user name.  </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > password </td>
+                <td> str  </td>
+                <td> True </td>
+                <td></td>
+                <td></td>
+                <td>  <br> VASA vendor provider password.  </td>
+            </tr>
+                                        <tr>
             <td colspan=2 > esxi_credentials</td>
             <td> list   <br> elements: dict </td>
             <td></td>
@@ -6073,7 +6647,7 @@ Manage networks for PowerStore
                 <td></td>
                 <td>  <br> Node identifier corresponding to the ESXi host.  </td>
             </tr>
-                    <tr>
+                                <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=1 > password </td>
                 <td> str  </td>
@@ -6082,119 +6656,21 @@ Manage networks for PowerStore
                 <td></td>
                 <td>  <br> ESXi host root password.  </td>
             </tr>
-                            <tr>
-            <td colspan=2 > user</td>
-            <td> str  </td>
-            <td> True </td>
-            <td></td>
-            <td></td>
-            <td> <br> The username of the PowerStore host. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > network_id</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> The ID of the network. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > verifycert</td>
+                                        <tr>
+            <td colspan=2 > wait_for_completion</td>
             <td> bool  </td>
-            <td> True </td>
             <td></td>
-            <td> <ul> <li>True</li>  <li>False</li> </ul></td>
-            <td> <br> Boolean variable to specify whether to validate SSL certificate or not.  <br> True - indicates that the SSL certificate should be verified. Set the environment variable REQUESTS_CA_BUNDLE to the path of the SSL certificate.  <br> False - indicates that the SSL certificate should not be verified. </td>
+            <td> False </td>
+            <td></td>
+            <td> <br> Flag to indicate if the operation should be run synchronously or asynchronously. True signifies synchronous execution. By default, modify operation will run asynchronously. </td>
         </tr>
                     <tr>
-            <td colspan=2 > password</td>
+            <td colspan=2 > state</td>
             <td> str  </td>
             <td> True </td>
             <td></td>
-            <td></td>
-            <td> <br> The password of the PowerStore host. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > vasa_provider_credentials</td>
-            <td> dict  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Credentials required for re-registering the VASA vendor provider during the reconfiguration of the cluster management IP address. </td>
-        </tr>
-                            <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > password </td>
-                <td> str  </td>
-                <td> True </td>
-                <td></td>
-                <td></td>
-                <td>  <br> VASA vendor provider password.  </td>
-            </tr>
-                    <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > username </td>
-                <td> str  </td>
-                <td> True </td>
-                <td></td>
-                <td></td>
-                <td>  <br> VASA vendor provider user name.  </td>
-            </tr>
-                            <tr>
-            <td colspan=2 > prefix_length</td>
-            <td> int  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Network prefix length. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > new_name</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> New name of the network. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > timeout</td>
-            <td> int  </td>
-            <td></td>
-            <td> 120 </td>
-            <td></td>
-            <td> <br> Time after which the connection will get terminated.  <br> It is to be mentioned in seconds. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > storage_discovery_address</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> New storage discovery IP address in IPv4 format.  <br> Specify empty string to remove the storage discovery IP address. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > vlan_id</td>
-            <td> int  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> The ID of the VLAN. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > network_name</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> The name of the network.  <br> This parameter is added in 2.0.0.0.  <br> Specify either network_name or network_id for any operation. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > mtu</td>
-            <td> int  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Maximum Transmission Unit (MTU) packet size set on network interfaces, in bytes. </td>
+            <td> <ul> <li>absent</li>  <li>present</li> </ul></td>
+            <td> <br> Define whether the network exist or not. </td>
         </tr>
                     <tr>
             <td colspan=2 > array_ip</td>
@@ -6205,22 +6681,46 @@ Manage networks for PowerStore
             <td> <br> IP or FQDN of the PowerStore management system. </td>
         </tr>
                     <tr>
-            <td colspan=2 > gateway</td>
-            <td> str  </td>
+            <td colspan=2 > verifycert</td>
+            <td> bool  </td>
+            <td> True </td>
             <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Network gateway in IPv4 format. IP version.  <br> Specify empty string to remove the gateway. </td>
+            <td> <ul> <li>True</li>  <li>False</li> </ul></td>
+            <td> <br> Boolean variable to specify whether to validate SSL certificate or not.  <br> True - indicates that the SSL certificate should be verified. Set the environment variable REQUESTS_CA_BUNDLE to the path of the SSL certificate.  <br> False - indicates that the SSL certificate should not be verified. </td>
         </tr>
                     <tr>
-            <td colspan=2 > wait_for_completion</td>
-            <td> bool  </td>
+            <td colspan=2 > user</td>
+            <td> str  </td>
+            <td> True </td>
             <td></td>
-            <td> False </td>
             <td></td>
-            <td> <br> Flag to indicate if the operation should be run synchronously or asynchronously. True signifies synchronous execution. By default, modify operation will run asynchronously. </td>
+            <td> <br> The username of the PowerStore host. </td>
         </tr>
-                                                                                            </table>
+                    <tr>
+            <td colspan=2 > password</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td></td>
+            <td> <br> The password of the PowerStore host. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > timeout</td>
+            <td> int  </td>
+            <td></td>
+            <td> 120 </td>
+            <td></td>
+            <td> <br> Time after which the connection will get terminated.  <br> It is to be mentioned in seconds. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > port</td>
+            <td> int  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Port number for the PowerStore array.  <br> If not passed, it will take 443 as default. </td>
+        </tr>
+                                                    </table>
 
 ### Notes
 * It is recommended to perform task asynchronously while changing cluster management address.
@@ -6348,7 +6848,7 @@ Manage networks for PowerStore
         <th>Returned</th>
         <th width="100%">Description</th>
     </tr>
-                                    <tr>
+                                                                                            <tr>
             <td colspan=5 > changed </td>
             <td>  bool </td>
             <td> always </td>
@@ -6375,99 +6875,12 @@ Manage networks for PowerStore
         </tr>
                             <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=4 > member_ips </td>
-                <td> complex </td>
-                <td>success</td>
-                <td> Properties of the IP pool address. </td>
-            </tr>
-                                         <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=3 > name </td>
-                    <td> str </td>
-                    <td>success</td>
-                    <td> Name of the IP address. </td>
-                </tr>
-                                             <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=3 > node_id </td>
-                    <td> str </td>
-                    <td>success</td>
-                    <td> Unique identifier of the cluster node to which the IP address belongs. </td>
-                </tr>
-                                             <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=3 > id </td>
-                    <td> str </td>
-                    <td>success</td>
-                    <td> Unique identifier of the IP address. </td>
-                </tr>
-                                             <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=3 > purposes </td>
-                    <td> list </td>
-                    <td>success</td>
-                    <td> IP address purposes. </td>
-                </tr>
-                                             <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=3 > appliance_id </td>
-                    <td> str </td>
-                    <td>success</td>
-                    <td> Unique identifier of the appliance to which the IP address belongs. </td>
-                </tr>
-                                             <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=3 > ip_port_id </td>
-                    <td> str </td>
-                    <td>success</td>
-                    <td> Unique identifier of the port that uses this IP address to provide access to storage network services, such as iSCSI. This attribute can be set only for an IP address used by networks of type Storage. </td>
-                </tr>
-                                             <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=3 > network_id </td>
-                    <td> str </td>
-                    <td>success</td>
-                    <td> Unique identifier of the network to which the IP address belongs. </td>
-                </tr>
-                                             <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=3 > address </td>
-                    <td> str </td>
-                    <td>success</td>
-                    <td> IP address value, in IPv4 or IPv6 format. </td>
-                </tr>
-                                                            <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=4 > cluster_details </td>
                 <td> complex </td>
                 <td>success</td>
                 <td> The details of the cluster. </td>
             </tr>
                                          <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=3 > name </td>
-                    <td> str </td>
-                    <td>success</td>
-                    <td> The name of the cluster. </td>
-                </tr>
-                                             <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=3 > storage_discovery_address </td>
-                    <td> str </td>
-                    <td>success</td>
-                    <td> The floating storage discovery IP address for the cluster in IPv4 or IPv6 format. </td>
-                </tr>
-                                             <tr>
                     <td class="elbow-placeholder">&nbsp;</td>
                     <td class="elbow-placeholder">&nbsp;</td>
                     <td colspan=3 > appliance_count </td>
@@ -6491,7 +6904,136 @@ Manage networks for PowerStore
                     <td>success</td>
                     <td> The floating management IP address for the cluster in IPv4 or IPv6 format. </td>
                 </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=3 > name </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> The name of the cluster. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=3 > storage_discovery_address </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> The floating storage discovery IP address for the cluster in IPv4 or IPv6 format. </td>
+                </tr>
                                                             <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=4 > gateway </td>
+                <td> str </td>
+                <td>success</td>
+                <td> The gateway of the network. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=4 > id </td>
+                <td> str </td>
+                <td>success</td>
+                <td> The ID of the network. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=4 > ip_version </td>
+                <td> str </td>
+                <td>success</td>
+                <td> IP protocol version </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=4 > member_ips </td>
+                <td> complex </td>
+                <td>success</td>
+                <td> Properties of the IP pool address. </td>
+            </tr>
+                                         <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=3 > address </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> IP address value, in IPv4 or IPv6 format. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=3 > appliance_id </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> Unique identifier of the appliance to which the IP address belongs. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=3 > id </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> Unique identifier of the IP address. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=3 > ip_port_id </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> Unique identifier of the port that uses this IP address to provide access to storage network services, such as iSCSI. This attribute can be set only for an IP address used by networks of type Storage. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=3 > name </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> Name of the IP address. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=3 > network_id </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> Unique identifier of the network to which the IP address belongs. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=3 > node_id </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> Unique identifier of the cluster node to which the IP address belongs. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=3 > purposes </td>
+                    <td> list </td>
+                    <td>success</td>
+                    <td> IP address purposes. </td>
+                </tr>
+                                                            <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=4 > mtu </td>
+                <td> int </td>
+                <td>success</td>
+                <td> Maximum Transmission Unit (MTU) packet size set on network interfaces, in bytes. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=4 > name </td>
+                <td> str </td>
+                <td>success</td>
+                <td> The name of the network. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=4 > prefix_length </td>
+                <td> int </td>
+                <td>success</td>
+                <td> Network prefix length. </td>
+            </tr>
+                                <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=4 > purposes </td>
                 <td> list </td>
@@ -6500,10 +7042,10 @@ Manage networks for PowerStore
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=4 > gateway </td>
+                <td colspan=4 > type </td>
                 <td> str </td>
                 <td>success</td>
-                <td> The gateway of the network. </td>
+                <td> Network type </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
@@ -6515,10 +7057,10 @@ Manage networks for PowerStore
                                          <tr>
                     <td class="elbow-placeholder">&nbsp;</td>
                     <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=3 > vendor_provider_status </td>
+                    <td colspan=3 > address </td>
                     <td> str </td>
                     <td>success</td>
-                    <td> General status of the VASA vendor provider in vCenter. </td>
+                    <td> IP address of vCenter host, in IPv4, IPv6, or hostname format. </td>
                 </tr>
                                              <tr>
                     <td class="elbow-placeholder">&nbsp;</td>
@@ -6527,14 +7069,6 @@ Manage networks for PowerStore
                     <td> str </td>
                     <td>success</td>
                     <td> Unique identifier of the vCenter instance. </td>
-                </tr>
-                                             <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=3 > address </td>
-                    <td> str </td>
-                    <td>success</td>
-                    <td> IP address of vCenter host, in IPv4, IPv6, or hostname format. </td>
                 </tr>
                                              <tr>
                     <td class="elbow-placeholder">&nbsp;</td>
@@ -6552,56 +7086,22 @@ Manage networks for PowerStore
                     <td>success</td>
                     <td> User name to login to vCenter. </td>
                 </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=3 > vendor_provider_status </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> General status of the VASA vendor provider in vCenter. </td>
+                </tr>
                                                             <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=4 > name </td>
-                <td> str </td>
-                <td>success</td>
-                <td> The name of the network. </td>
-            </tr>
-                                <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=4 > vlan_id </td>
                 <td> int </td>
                 <td>success</td>
                 <td> VLAN identifier. </td>
             </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=4 > id </td>
-                <td> str </td>
-                <td>success</td>
-                <td> The ID of the network. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=4 > mtu </td>
-                <td> int </td>
-                <td>success</td>
-                <td> Maximum Transmission Unit (MTU) packet size set on network interfaces, in bytes. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=4 > ip_version </td>
-                <td> str </td>
-                <td>success</td>
-                <td> IP protocol version </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=4 > prefix_length </td>
-                <td> int </td>
-                <td>success</td>
-                <td> Network prefix length. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=4 > type </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Network type </td>
-            </tr>
-                                                                                                </table>
+                                        </table>
 
 ### Authors
 * Akash Shendge (@shenda1) <ansible.team@dell.com>
@@ -6625,53 +7125,13 @@ Manage NFS exports for PowerStore
         <th>Choices</th>
         <th width="80%">Description</th>
     </tr>
-                    <tr>
-            <td colspan=1 > read_write_root_hosts</td>
-            <td> list   <br> elements: str </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Hosts with read and write access for root user to the NFS export. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > filesystem</td>
+                                                            <tr>
+            <td colspan=1 > nfs_export_name</td>
             <td> str  </td>
             <td></td>
             <td></td>
             <td></td>
-            <td> <br> The ID/Name of the filesystem for which the NFS export will be created.  <br> Either filesystem or snapshot is required for creation of the NFS Export.  <br> If filesystem name is specified, then nas_server is required to uniquely identify the filesystem.  <br> If filesystem parameter is provided, then snapshot cannot be specified. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > default_access</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td> <ul> <li>NO_ACCESS</li>  <li>READ_ONLY</li>  <li>READ_WRITE</li>  <li>ROOT</li>  <li>READ_ONLY_ROOT</li> </ul></td>
-            <td> <br> Default access level for all hosts that can access the Export.  <br> For hosts that need different access than the default, they can be configured by adding to the list.  <br> If default_access is not mentioned during creation, then NFS export will be created with No_Access. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > port</td>
-            <td> int  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Port number for the PowerStore array.  <br> If not passed, it will take 443 as default. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > read_only_root_hosts</td>
-            <td> list   <br> elements: str </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Hosts with read-only access for root user to the NFS export. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > is_no_suid</td>
-            <td> bool  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> If set, do not allow access to set SUID. Otherwise, allow access.  <br> If not specified at the time of creation, it will be set to False. </td>
+            <td> <br> The name of the NFS export.  <br> Mandatory for create operation.  <br> Specify either nfs_export_name or nfs_export_id(but not both) for any operation. </td>
         </tr>
                     <tr>
             <td colspan=1 > nfs_export_id</td>
@@ -6682,76 +7142,12 @@ Manage NFS exports for PowerStore
             <td> <br> The ID of the NFS export. </td>
         </tr>
                     <tr>
-            <td colspan=1 > user</td>
-            <td> str  </td>
-            <td> True </td>
-            <td></td>
-            <td></td>
-            <td> <br> The username of the PowerStore host. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > anonymous_gid</td>
-            <td> int  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Specifies the group ID of the anonymous account.  <br> If not specified at the time of creation, it will be set to -2. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > verifycert</td>
-            <td> bool  </td>
-            <td> True </td>
-            <td></td>
-            <td> <ul> <li>True</li>  <li>False</li> </ul></td>
-            <td> <br> Boolean variable to specify whether to validate SSL certificate or not.  <br> True - indicates that the SSL certificate should be verified. Set the environment variable REQUESTS_CA_BUNDLE to the path of the SSL certificate.  <br> False - indicates that the SSL certificate should not be verified. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > min_security</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td> <ul> <li>SYS</li>  <li>KERBEROS</li>  <li>KERBEROS_WITH_INTEGRITY</li>  <li>KERBEROS_WITH_ENCRYPTION</li> </ul></td>
-            <td> <br> NFS enforced security type for users accessing an NFS export.  <br> If not specified at the time of creation, it will be set to SYS. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > password</td>
-            <td> str  </td>
-            <td> True </td>
-            <td></td>
-            <td></td>
-            <td> <br> The password of the PowerStore host. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > anonymous_uid</td>
-            <td> int  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Specifies the user ID of the anonymous account.  <br> If not specified at the time of creation, it will be set to -2. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > host_state</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td> <ul> <li>present-in-export</li>  <li>absent-in-export</li> </ul></td>
-            <td> <br> Define whether the hosts can access the NFS export.  <br> Required when adding or removing host access from the export. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > no_access_hosts</td>
-            <td> list   <br> elements: str </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Hosts with no access to the NFS export. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > path</td>
+            <td colspan=1 > filesystem</td>
             <td> str  </td>
             <td></td>
             <td></td>
             <td></td>
-            <td> <br> Local path to export relative to the NAS server root.  <br> With NFS, each export of a file_system or file_snap must have a unique local path.  <br> Mandatory while creating NFS export. </td>
+            <td> <br> The ID/Name of the filesystem for which the NFS export will be created.  <br> Either filesystem or snapshot is required for creation of the NFS Export.  <br> If filesystem name is specified, then nas_server is required to uniquely identify the filesystem.  <br> If filesystem parameter is provided, then snapshot cannot be specified. </td>
         </tr>
                     <tr>
             <td colspan=1 > snapshot</td>
@@ -6762,30 +7158,6 @@ Manage NFS exports for PowerStore
             <td> <br> The ID/Name of the Snapshot for which NFS export will be created.  <br> Either filesystem or snapshot is required for creation of the NFS Export.  <br> If snapshot name is specified, then nas_server is required to uniquely identify the snapshot.  <br> If snapshot parameter is provided, then filesystem cannot be specified.  <br> NFS export can be created only if access type of snapshot is "protocol". </td>
         </tr>
                     <tr>
-            <td colspan=1 > nfs_export_name</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> The name of the NFS export.  <br> Mandatory for create operation.  <br> Specify either nfs_export_name or nfs_export_id(but not both) for any operation. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > read_write_hosts</td>
-            <td> list   <br> elements: str </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Hosts with read and write access to the NFS export. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > timeout</td>
-            <td> int  </td>
-            <td></td>
-            <td> 120 </td>
-            <td></td>
-            <td> <br> Time after which the connection will get terminated.  <br> It is to be mentioned in seconds. </td>
-        </tr>
-                    <tr>
             <td colspan=1 > nas_server</td>
             <td> str  </td>
             <td></td>
@@ -6794,20 +7166,12 @@ Manage NFS exports for PowerStore
             <td> <br> The NAS server. This could be the name or ID of the NAS server. </td>
         </tr>
                     <tr>
-            <td colspan=1 > array_ip</td>
+            <td colspan=1 > path</td>
             <td> str  </td>
-            <td> True </td>
             <td></td>
             <td></td>
-            <td> <br> IP or FQDN of the PowerStore management system. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > state</td>
-            <td> str  </td>
-            <td> True </td>
             <td></td>
-            <td> <ul> <li>absent</li>  <li>present</li> </ul></td>
-            <td> <br> Define whether the NFS export should exist or not. </td>
+            <td> <br> Local path to export relative to the NAS server root.  <br> With NFS, each export of a file_system or file_snap must have a unique local path.  <br> Mandatory while creating NFS export. </td>
         </tr>
                     <tr>
             <td colspan=1 > description</td>
@@ -6818,6 +7182,22 @@ Manage NFS exports for PowerStore
             <td> <br> The description for the NFS export. </td>
         </tr>
                     <tr>
+            <td colspan=1 > default_access</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td> <ul> <li>NO_ACCESS</li>  <li>READ_ONLY</li>  <li>READ_WRITE</li>  <li>ROOT</li>  <li>READ_ONLY_ROOT</li> </ul></td>
+            <td> <br> Default access level for all hosts that can access the Export.  <br> For hosts that need different access than the default, they can be configured by adding to the list.  <br> If default_access is not mentioned during creation, then NFS export will be created with No_Access. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > no_access_hosts</td>
+            <td> list   <br> elements: str </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Hosts with no access to the NFS export. </td>
+        </tr>
+                    <tr>
             <td colspan=1 > read_only_hosts</td>
             <td> list   <br> elements: str </td>
             <td></td>
@@ -6825,7 +7205,127 @@ Manage NFS exports for PowerStore
             <td></td>
             <td> <br> Hosts with read-only access to the NFS export. </td>
         </tr>
-                                                                                            </table>
+                    <tr>
+            <td colspan=1 > read_only_root_hosts</td>
+            <td> list   <br> elements: str </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Hosts with read-only access for root user to the NFS export. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > read_write_hosts</td>
+            <td> list   <br> elements: str </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Hosts with read and write access to the NFS export. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > read_write_root_hosts</td>
+            <td> list   <br> elements: str </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Hosts with read and write access for root user to the NFS export. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > min_security</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td> <ul> <li>SYS</li>  <li>KERBEROS</li>  <li>KERBEROS_WITH_INTEGRITY</li>  <li>KERBEROS_WITH_ENCRYPTION</li> </ul></td>
+            <td> <br> NFS enforced security type for users accessing an NFS export.  <br> If not specified at the time of creation, it will be set to SYS. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > anonymous_uid</td>
+            <td> int  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Specifies the user ID of the anonymous account.  <br> If not specified at the time of creation, it will be set to -2. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > anonymous_gid</td>
+            <td> int  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Specifies the group ID of the anonymous account.  <br> If not specified at the time of creation, it will be set to -2. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > is_no_suid</td>
+            <td> bool  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> If set, do not allow access to set SUID. Otherwise, allow access.  <br> If not specified at the time of creation, it will be set to False. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > host_state</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td> <ul> <li>present-in-export</li>  <li>absent-in-export</li> </ul></td>
+            <td> <br> Define whether the hosts can access the NFS export.  <br> Required when adding or removing host access from the export. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > state</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td> <ul> <li>absent</li>  <li>present</li> </ul></td>
+            <td> <br> Define whether the NFS export should exist or not. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > array_ip</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td></td>
+            <td> <br> IP or FQDN of the PowerStore management system. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > verifycert</td>
+            <td> bool  </td>
+            <td> True </td>
+            <td></td>
+            <td> <ul> <li>True</li>  <li>False</li> </ul></td>
+            <td> <br> Boolean variable to specify whether to validate SSL certificate or not.  <br> True - indicates that the SSL certificate should be verified. Set the environment variable REQUESTS_CA_BUNDLE to the path of the SSL certificate.  <br> False - indicates that the SSL certificate should not be verified. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > user</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td></td>
+            <td> <br> The username of the PowerStore host. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > password</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td></td>
+            <td> <br> The password of the PowerStore host. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > timeout</td>
+            <td> int  </td>
+            <td></td>
+            <td> 120 </td>
+            <td></td>
+            <td> <br> Time after which the connection will get terminated.  <br> It is to be mentioned in seconds. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > port</td>
+            <td> int  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Port number for the PowerStore array.  <br> If not passed, it will take 443 as default. </td>
+        </tr>
+                                                    </table>
 
 ### Notes
 * The check_mode is not supported.
@@ -6942,7 +7442,13 @@ Manage NFS exports for PowerStore
         <th>Returned</th>
         <th width="100%">Description</th>
     </tr>
-                                    <tr>
+                                                                                            <tr>
+            <td colspan=4 > changed </td>
+            <td>  bool </td>
+            <td> always </td>
+            <td> Whether or not the resource has changed. </td>
+        </tr>
+                    <tr>
             <td colspan=4 > nfs_export_details </td>
             <td>  complex </td>
             <td> When NFS export exists. </td>
@@ -6950,10 +7456,116 @@ Manage NFS exports for PowerStore
         </tr>
                             <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=3 > read_write_root_hosts </td>
-                <td> list </td>
+                <td colspan=3 > anonymous_GID </td>
+                <td> int </td>
                 <td>success</td>
-                <td> Hosts with read and write for root user access to the NFS export. </td>
+                <td> The group ID of the anonymous account. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=3 > anonymous_UID </td>
+                <td> int </td>
+                <td>success</td>
+                <td> The user ID of the anonymous account. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=3 > default_access </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Default access level for all hosts that can access the export. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=3 > description </td>
+                <td> str </td>
+                <td>success</td>
+                <td> The description for the NFS export. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=3 > file_system </td>
+                <td> complex </td>
+                <td>success</td>
+                <td> Details of filesystem and NAS server on which NFS export is present. </td>
+            </tr>
+                                         <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=2 > filesystem_type </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> The type of the filesystem. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=2 > id </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> The ID of the filesystem. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=2 > name </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> The name of the filesystem. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=2 > nas_server </td>
+                    <td> complex </td>
+                    <td>success</td>
+                    <td> Details of NAS server. </td>
+                </tr>
+                                                    <tr>
+                        <td class="elbow-placeholder">&nbsp;</td>
+                        <td class="elbow-placeholder">&nbsp;</td>
+                        <td class="elbow-placeholder">&nbsp;</td>
+                        <td colspan=1 > id </td>
+                        <td> str </td>
+                        <td>success</td>
+                        <td> The ID of the NAS server. </td>
+                    </tr>
+                                    <tr>
+                        <td class="elbow-placeholder">&nbsp;</td>
+                        <td class="elbow-placeholder">&nbsp;</td>
+                        <td class="elbow-placeholder">&nbsp;</td>
+                        <td colspan=1 > name </td>
+                        <td> str </td>
+                        <td>success</td>
+                        <td> The name of the NAS server. </td>
+                    </tr>
+                                                                            <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=3 > id </td>
+                <td> str </td>
+                <td>success</td>
+                <td> The ID of the NFS export. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=3 > is_no_SUID </td>
+                <td> bool </td>
+                <td>success</td>
+                <td> If set, do not allow access to set SUID. Otherwise, allow access. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=3 > min_security </td>
+                <td> str </td>
+                <td>success</td>
+                <td> NFS enforced security type for users accessing an NFS export. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=3 > name </td>
+                <td> str </td>
+                <td>success</td>
+                <td> The name of the NFS export. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
@@ -6971,69 +7583,12 @@ Manage NFS exports for PowerStore
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=3 > anonymous_GID </td>
-                <td> int </td>
+                <td colspan=3 > read_only_hosts </td>
+                <td> list </td>
                 <td>success</td>
-                <td> The group ID of the anonymous account. </td>
+                <td> Hosts with read-only access to the NFS export. </td>
             </tr>
                                 <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=3 > file_system </td>
-                <td> complex </td>
-                <td>success</td>
-                <td> Details of filesystem and NAS server on which NFS export is present. </td>
-            </tr>
-                                         <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=2 > name </td>
-                    <td> str </td>
-                    <td>success</td>
-                    <td> The name of the filesystem. </td>
-                </tr>
-                                             <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=2 > filesystem_type </td>
-                    <td> str </td>
-                    <td>success</td>
-                    <td> The type of the filesystem. </td>
-                </tr>
-                                             <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=2 > nas_server </td>
-                    <td> complex </td>
-                    <td>success</td>
-                    <td> Details of NAS server. </td>
-                </tr>
-                                                    <tr>
-                        <td class="elbow-placeholder">&nbsp;</td>
-                        <td class="elbow-placeholder">&nbsp;</td>
-                        <td class="elbow-placeholder">&nbsp;</td>
-                        <td colspan=1 > name </td>
-                        <td> str </td>
-                        <td>success</td>
-                        <td> The name of the NAS server. </td>
-                    </tr>
-                                    <tr>
-                        <td class="elbow-placeholder">&nbsp;</td>
-                        <td class="elbow-placeholder">&nbsp;</td>
-                        <td class="elbow-placeholder">&nbsp;</td>
-                        <td colspan=1 > id </td>
-                        <td> str </td>
-                        <td>success</td>
-                        <td> The ID of the NAS server. </td>
-                    </tr>
-                                                             <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=2 > id </td>
-                    <td> str </td>
-                    <td>success</td>
-                    <td> The ID of the filesystem. </td>
-                </tr>
-                                                            <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=3 > read_only_root_hosts </td>
                 <td> list </td>
@@ -7049,67 +7604,12 @@ Manage NFS exports for PowerStore
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=3 > name </td>
-                <td> str </td>
-                <td>success</td>
-                <td> The name of the NFS export. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=3 > id </td>
-                <td> str </td>
-                <td>success</td>
-                <td> The ID of the NFS export. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=3 > default_access </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Default access level for all hosts that can access the export. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=3 > anonymous_UID </td>
-                <td> int </td>
-                <td>success</td>
-                <td> The user ID of the anonymous account. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=3 > min_security </td>
-                <td> str </td>
-                <td>success</td>
-                <td> NFS enforced security type for users accessing an NFS export. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=3 > description </td>
-                <td> str </td>
-                <td>success</td>
-                <td> The description for the NFS export. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=3 > is_no_SUID </td>
-                <td> bool </td>
-                <td>success</td>
-                <td> If set, do not allow access to set SUID. Otherwise, allow access. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=3 > read_only_hosts </td>
+                <td colspan=3 > read_write_root_hosts </td>
                 <td> list </td>
                 <td>success</td>
-                <td> Hosts with read-only access to the NFS export. </td>
+                <td> Hosts with read and write for root user access to the NFS export. </td>
             </tr>
-                                        <tr>
-            <td colspan=4 > changed </td>
-            <td>  bool </td>
-            <td> always </td>
-            <td> Whether or not the resource has changed. </td>
-        </tr>
-                                                                            </table>
+                                        </table>
 
 ### Authors
 * Akash Shendge (@shenda1) <ansible.team@dell.com>
@@ -7133,13 +7633,13 @@ NTP operations on a PowerStore storage system
         <th>Choices</th>
         <th width="80%">Description</th>
     </tr>
-                    <tr>
-            <td colspan=1 > timeout</td>
-            <td> int  </td>
+                                                            <tr>
+            <td colspan=1 > ntp_id</td>
+            <td> str  </td>
+            <td> True </td>
             <td></td>
-            <td> 120 </td>
             <td></td>
-            <td> <br> Time after which the connection will get terminated.  <br> It is to be mentioned in seconds. </td>
+            <td> <br> Unique identifier of the NTP instance. </td>
         </tr>
                     <tr>
             <td colspan=1 > ntp_addresses</td>
@@ -7158,12 +7658,12 @@ NTP operations on a PowerStore storage system
             <td> <br> State of the addresses mentioned in ntp_addresses. </td>
         </tr>
                     <tr>
-            <td colspan=1 > ntp_id</td>
+            <td colspan=1 > state</td>
             <td> str  </td>
             <td> True </td>
             <td></td>
-            <td></td>
-            <td> <br> Unique identifier of the NTP instance. </td>
+            <td> <ul> <li>present</li>  <li>absent</li> </ul></td>
+            <td> <br> The state of the NTP instance after the task is performed.  <br> For get and modify operations it should be set to "present". </td>
         </tr>
                     <tr>
             <td colspan=1 > array_ip</td>
@@ -7174,14 +7674,6 @@ NTP operations on a PowerStore storage system
             <td> <br> IP or FQDN of the PowerStore management system. </td>
         </tr>
                     <tr>
-            <td colspan=1 > state</td>
-            <td> str  </td>
-            <td> True </td>
-            <td></td>
-            <td> <ul> <li>present</li>  <li>absent</li> </ul></td>
-            <td> <br> The state of the NTP instance after the task is performed.  <br> For get and modify operations it should be set to "present". </td>
-        </tr>
-                    <tr>
             <td colspan=1 > verifycert</td>
             <td> bool  </td>
             <td> True </td>
@@ -7190,12 +7682,12 @@ NTP operations on a PowerStore storage system
             <td> <br> Boolean variable to specify whether to validate SSL certificate or not.  <br> True - indicates that the SSL certificate should be verified. Set the environment variable REQUESTS_CA_BUNDLE to the path of the SSL certificate.  <br> False - indicates that the SSL certificate should not be verified. </td>
         </tr>
                     <tr>
-            <td colspan=1 > port</td>
-            <td> int  </td>
+            <td colspan=1 > user</td>
+            <td> str  </td>
+            <td> True </td>
             <td></td>
             <td></td>
-            <td></td>
-            <td> <br> Port number for the PowerStore array.  <br> If not passed, it will take 443 as default. </td>
+            <td> <br> The username of the PowerStore host. </td>
         </tr>
                     <tr>
             <td colspan=1 > password</td>
@@ -7206,14 +7698,22 @@ NTP operations on a PowerStore storage system
             <td> <br> The password of the PowerStore host. </td>
         </tr>
                     <tr>
-            <td colspan=1 > user</td>
-            <td> str  </td>
-            <td> True </td>
+            <td colspan=1 > timeout</td>
+            <td> int  </td>
             <td></td>
+            <td> 120 </td>
             <td></td>
-            <td> <br> The username of the PowerStore host. </td>
+            <td> <br> Time after which the connection will get terminated.  <br> It is to be mentioned in seconds. </td>
         </tr>
-                                                                                            </table>
+                    <tr>
+            <td colspan=1 > port</td>
+            <td> int  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Port number for the PowerStore array.  <br> If not passed, it will take 443 as default. </td>
+        </tr>
+                                                    </table>
 
 ### Notes
 * Minimum 1 and maximum 3 addresses can be associated to a NTP instance.
@@ -7268,7 +7768,13 @@ NTP operations on a PowerStore storage system
         <th>Returned</th>
         <th width="100%">Description</th>
     </tr>
-                                    <tr>
+                                                                                            <tr>
+            <td colspan=2 > changed </td>
+            <td>  bool </td>
+            <td> always </td>
+            <td> Shows whether or not the resource has changed. </td>
+        </tr>
+                    <tr>
             <td colspan=2 > ntp_details </td>
             <td>  complex </td>
             <td> When NTP exists. </td>
@@ -7288,13 +7794,7 @@ NTP operations on a PowerStore storage system
                 <td>success</td>
                 <td> Unique identifier of NTP instance. </td>
             </tr>
-                                        <tr>
-            <td colspan=2 > changed </td>
-            <td>  bool </td>
-            <td> always </td>
-            <td> Shows whether or not the resource has changed. </td>
-        </tr>
-                                                                            </table>
+                                        </table>
 
 ### Authors
 * Bhavneet Sharma (@sharmb5) <ansible.team@dell.com>
@@ -7318,21 +7818,13 @@ Perform Protection policy operations for PowerStore storage system
         <th>Choices</th>
         <th width="80%">Description</th>
     </tr>
-                    <tr>
-            <td colspan=1 > snapshotrules</td>
-            <td> list   <br> elements: str </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> List of strings to specify the name or ids of snapshot rules which are to be added or removed, to or from, the protection policy. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > array_ip</td>
+                                                            <tr>
+            <td colspan=1 > name</td>
             <td> str  </td>
-            <td> True </td>
             <td></td>
             <td></td>
-            <td> <br> IP or FQDN of the PowerStore management system. </td>
+            <td></td>
+            <td> <br> String variable. Indicates the name of the protection policy. </td>
         </tr>
                     <tr>
             <td colspan=1 > protectionpolicy_id</td>
@@ -7343,20 +7835,28 @@ Perform Protection policy operations for PowerStore storage system
             <td> <br> String variable. Indicates the id of the protection policy. </td>
         </tr>
                     <tr>
-            <td colspan=1 > port</td>
-            <td> int  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Port number for the PowerStore array.  <br> If not passed, it will take 443 as default. </td>
-        </tr>
-                    <tr>
             <td colspan=1 > new_name</td>
             <td> str  </td>
             <td></td>
             <td></td>
             <td></td>
             <td> <br> String variable. Indicates the new name of the protection policy.  <br> Used for renaming operation. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > snapshotrules</td>
+            <td> list   <br> elements: str </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> List of strings to specify the name or ids of snapshot rules which are to be added or removed, to or from, the protection policy. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > replicationrule</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> The name or ids of the replcation rule which is to be added to the protection policy.  <br> To remove the replication rule, an empty string has to be passed. </td>
         </tr>
                     <tr>
             <td colspan=1 > description</td>
@@ -7367,12 +7867,12 @@ Perform Protection policy operations for PowerStore storage system
             <td> <br> String variable. Indicates the description of the protection policy. </td>
         </tr>
                     <tr>
-            <td colspan=1 > name</td>
+            <td colspan=1 > state</td>
             <td> str  </td>
+            <td> True </td>
             <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> String variable. Indicates the name of the protection policy. </td>
+            <td> <ul> <li>present</li>  <li>absent</li> </ul></td>
+            <td> <br> String variable. Indicates the state of protection policy.  <br> For Delete operation only, it should be set to "absent".  <br> For all other operations like Create, Modify or Get details, it should be set to "present". </td>
         </tr>
                     <tr>
             <td colspan=1 > snapshotrule_state</td>
@@ -7383,28 +7883,12 @@ Perform Protection policy operations for PowerStore storage system
             <td> <br> String variable. Indicates the state of a snapshotrule in a protection policy.  <br> When snapshot rules are specified, this variable is required.  <br> Value present-in-policy indicates to add to protection policy.  <br> Value absent-in-policy indicates to remove from protection policy. </td>
         </tr>
                     <tr>
-            <td colspan=1 > user</td>
+            <td colspan=1 > array_ip</td>
             <td> str  </td>
             <td> True </td>
             <td></td>
             <td></td>
-            <td> <br> The username of the PowerStore host. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > state</td>
-            <td> str  </td>
-            <td> True </td>
-            <td></td>
-            <td> <ul> <li>present</li>  <li>absent</li> </ul></td>
-            <td> <br> String variable. Indicates the state of protection policy.  <br> For Delete operation only, it should be set to "absent".  <br> For all other operations like Create, Modify or Get details, it should be set to "present". </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > timeout</td>
-            <td> int  </td>
-            <td></td>
-            <td> 120 </td>
-            <td></td>
-            <td> <br> Time after which the connection will get terminated.  <br> It is to be mentioned in seconds. </td>
+            <td> <br> IP or FQDN of the PowerStore management system. </td>
         </tr>
                     <tr>
             <td colspan=1 > verifycert</td>
@@ -7415,6 +7899,14 @@ Perform Protection policy operations for PowerStore storage system
             <td> <br> Boolean variable to specify whether to validate SSL certificate or not.  <br> True - indicates that the SSL certificate should be verified. Set the environment variable REQUESTS_CA_BUNDLE to the path of the SSL certificate.  <br> False - indicates that the SSL certificate should not be verified. </td>
         </tr>
                     <tr>
+            <td colspan=1 > user</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td></td>
+            <td> <br> The username of the PowerStore host. </td>
+        </tr>
+                    <tr>
             <td colspan=1 > password</td>
             <td> str  </td>
             <td> True </td>
@@ -7423,14 +7915,22 @@ Perform Protection policy operations for PowerStore storage system
             <td> <br> The password of the PowerStore host. </td>
         </tr>
                     <tr>
-            <td colspan=1 > replicationrule</td>
-            <td> str  </td>
+            <td colspan=1 > timeout</td>
+            <td> int  </td>
             <td></td>
+            <td> 120 </td>
             <td></td>
-            <td></td>
-            <td> <br> The name or ids of the replcation rule which is to be added to the protection policy.  <br> To remove the replication rule, an empty string has to be passed. </td>
+            <td> <br> Time after which the connection will get terminated.  <br> It is to be mentioned in seconds. </td>
         </tr>
-                                                                                            </table>
+                    <tr>
+            <td colspan=1 > port</td>
+            <td> int  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Port number for the PowerStore array.  <br> If not passed, it will take 443 as default. </td>
+        </tr>
+                                                    </table>
 
 ### Notes
 * Before deleting a protection policy, the replication rule has to be removed from the protection policy.
@@ -7528,7 +8028,13 @@ Perform Protection policy operations for PowerStore storage system
         <th>Returned</th>
         <th width="100%">Description</th>
     </tr>
-                                    <tr>
+                                                                                            <tr>
+            <td colspan=4 > changed </td>
+            <td>  bool </td>
+            <td> always </td>
+            <td> Whether or not the resource has changed. </td>
+        </tr>
+                    <tr>
             <td colspan=4 > protectionpolicy_details </td>
             <td>  complex </td>
             <td> When protection policy exists </td>
@@ -7536,10 +8042,10 @@ Perform Protection policy operations for PowerStore storage system
         </tr>
                             <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=3 > name </td>
+                <td colspan=3 > description </td>
                 <td> str </td>
                 <td>success</td>
-                <td> Name of the protection policy. </td>
+                <td> description about the protection policy. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
@@ -7550,28 +8056,12 @@ Perform Protection policy operations for PowerStore storage system
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=3 > snapshot_rules </td>
-                <td> complex </td>
+                <td colspan=3 > name </td>
+                <td> str </td>
                 <td>success</td>
-                <td> The snapshot rules details of the protection policy. </td>
+                <td> Name of the protection policy. </td>
             </tr>
-                                         <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=2 > name </td>
-                    <td> str </td>
-                    <td>success</td>
-                    <td> The snapshot rule name of the protection policy. </td>
-                </tr>
-                                             <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=2 > id </td>
-                    <td> str </td>
-                    <td>success</td>
-                    <td> The snapshot rule ID of the protection policy. </td>
-                </tr>
-                                                            <tr>
+                                <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=3 > replication_rules </td>
                 <td> complex </td>
@@ -7581,18 +8071,41 @@ Perform Protection policy operations for PowerStore storage system
                                          <tr>
                     <td class="elbow-placeholder">&nbsp;</td>
                     <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=2 > id </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> The replication rule ID of the protection policy. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
                     <td colspan=2 > name </td>
                     <td> str </td>
                     <td>success</td>
                     <td> The replication rule name of the protection policy. </td>
                 </tr>
-                                             <tr>
+                                                            <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=3 > snapshot_rules </td>
+                <td> complex </td>
+                <td>success</td>
+                <td> The snapshot rules details of the protection policy. </td>
+            </tr>
+                                         <tr>
                     <td class="elbow-placeholder">&nbsp;</td>
                     <td class="elbow-placeholder">&nbsp;</td>
                     <td colspan=2 > id </td>
                     <td> str </td>
                     <td>success</td>
-                    <td> The replication rule ID of the protection policy. </td>
+                    <td> The snapshot rule ID of the protection policy. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=2 > name </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> The snapshot rule name of the protection policy. </td>
                 </tr>
                                                             <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
@@ -7601,20 +8114,7 @@ Perform Protection policy operations for PowerStore storage system
                 <td>success</td>
                 <td> The type for the protection policy. </td>
             </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=3 > description </td>
-                <td> str </td>
-                <td>success</td>
-                <td> description about the protection policy. </td>
-            </tr>
-                                        <tr>
-            <td colspan=4 > changed </td>
-            <td>  bool </td>
-            <td> always </td>
-            <td> Whether or not the resource has changed. </td>
-        </tr>
-                                                                            </table>
+                                        </table>
 
 ### Authors
 * Arindam Datta (@dattaarindam) <ansible.team@dell.com>
@@ -7629,7 +8129,7 @@ Manage Tree Quotas and User Quotas on PowerStore
  Managing  Quotas on PowerStore storage system includes getting details, modifying, creating and deleting Quotas.
 
 ### Parameters
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
 <table>
     <tr>
         <th colspan=2>Parameter</th>
@@ -7639,6 +8139,14 @@ Manage Tree Quotas and User Quotas on PowerStore
         <th>Choices</th>
         <th width="80%">Description</th>
     </tr>
+                                                            <tr>
+            <td colspan=2 > path</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> The path on which the quota will be imposed.  <br> Path is relative to the root of the filesystem.  <br> For user quota, if path is not specified, quota will be created at the root of the filesystem. </td>
+        </tr>
                     <tr>
             <td colspan=2 > quota_type</td>
             <td> str  </td>
@@ -7648,52 +8156,20 @@ Manage Tree Quotas and User Quotas on PowerStore
             <td> <br> The type of quota which will be imposed. </td>
         </tr>
                     <tr>
-            <td colspan=2 > windows_name</td>
+            <td colspan=2 > quota_id</td>
             <td> str  </td>
             <td></td>
             <td></td>
             <td></td>
-            <td> <br> The name of the Windows User for which quota operations will be performed.  <br> The name should be mentioned along with Domain Name as 'DOMAIN_NAME\user_name' or as "DOMAIN_NAME\\user_name".  <br> Any one among uid/unix_name/windows_name/windows_sid is required when quota_type is 'user'. </td>
+            <td> <br> Id of the user/tree quota.  <br> If quota_id is mentioned, then path/nas_server/file_system/quota_type is not required. </td>
         </tr>
                     <tr>
-            <td colspan=2 > array_ip</td>
-            <td> str  </td>
-            <td> True </td>
-            <td></td>
-            <td></td>
-            <td> <br> IP or FQDN of the PowerStore management system. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > uid</td>
-            <td> int  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> The ID of the unix user account for which quota operations will be performed.  <br> Any one among uid/unix_name/windows_name/windows_sid is required when quota_type is 'user'. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > port</td>
-            <td> int  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Port number for the PowerStore array.  <br> If not passed, it will take 443 as default. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > path</td>
+            <td colspan=2 > filesystem</td>
             <td> str  </td>
             <td></td>
             <td></td>
             <td></td>
-            <td> <br> The path on which the quota will be imposed.  <br> Path is relative to the root of the filesystem.  <br> For user quota, if path is not specified, quota will be created at the root of the filesystem. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > unix_name</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> The name of the unix user account for which quota operations will be performed.  <br> Any one among uid/unix_name/windows_name/windows_sid is required when quota_type is 'user'. </td>
+            <td> <br> The ID/Name of the filesystem for which the Tree/User Quota  will be created.  <br> If filesystem name is specified, then nas_server is required to uniquely identify the filesystem. </td>
         </tr>
                     <tr>
             <td colspan=2 > nas_server</td>
@@ -7712,12 +8188,28 @@ Manage Tree Quotas and User Quotas on PowerStore
             <td> <br> Additional information that can be mentioned for a Tree Quota.  <br> Description parameter can only be used when quota_type is 'tree'. </td>
         </tr>
                     <tr>
-            <td colspan=2 > timeout</td>
+            <td colspan=2 > unix_name</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> The name of the unix user account for which quota operations will be performed.  <br> Any one among uid/unix_name/windows_name/windows_sid is required when quota_type is 'user'. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > windows_name</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> The name of the Windows User for which quota operations will be performed.  <br> The name should be mentioned along with Domain Name as 'DOMAIN_NAME\user_name' or as "DOMAIN_NAME\\user_name".  <br> Any one among uid/unix_name/windows_name/windows_sid is required when quota_type is 'user'. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > uid</td>
             <td> int  </td>
             <td></td>
-            <td> 120 </td>
             <td></td>
-            <td> <br> Time after which the connection will get terminated.  <br> It is to be mentioned in seconds. </td>
+            <td></td>
+            <td> <br> The ID of the unix user account for which quota operations will be performed.  <br> Any one among uid/unix_name/windows_name/windows_sid is required when quota_type is 'user'. </td>
         </tr>
                     <tr>
             <td colspan=2 > windows_sid</td>
@@ -7726,54 +8218,6 @@ Manage Tree Quotas and User Quotas on PowerStore
             <td></td>
             <td></td>
             <td> <br> The SID of the Windows User account for which quota operations will be performed.  <br> Any one among uid/unix_name/windows_name/windows_sid is required when quota_type is 'user'. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > user</td>
-            <td> str  </td>
-            <td> True </td>
-            <td></td>
-            <td></td>
-            <td> <br> The username of the PowerStore host. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > state</td>
-            <td> str  </td>
-            <td> True </td>
-            <td></td>
-            <td> <ul> <li>absent</li>  <li>present</li> </ul></td>
-            <td> <br> Define whether the Quota should exist or not.  <br> Value present  indicates that the Quota should exist on the system.  <br> Value absent  indicates that the Quota should not exist on the system. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > filesystem</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> The ID/Name of the filesystem for which the Tree/User Quota  will be created.  <br> If filesystem name is specified, then nas_server is required to uniquely identify the filesystem. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > verifycert</td>
-            <td> bool  </td>
-            <td> True </td>
-            <td></td>
-            <td> <ul> <li>True</li>  <li>False</li> </ul></td>
-            <td> <br> Boolean variable to specify whether to validate SSL certificate or not.  <br> True - indicates that the SSL certificate should be verified. Set the environment variable REQUESTS_CA_BUNDLE to the path of the SSL certificate.  <br> False - indicates that the SSL certificate should not be verified. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > password</td>
-            <td> str  </td>
-            <td> True </td>
-            <td></td>
-            <td></td>
-            <td> <br> The password of the PowerStore host. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > quota_id</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Id of the user/tree quota.  <br> If quota_id is mentioned, then path/nas_server/file_system/quota_type is not required. </td>
         </tr>
                     <tr>
             <td colspan=2 > quota</td>
@@ -7785,15 +8229,6 @@ Manage Tree Quotas and User Quotas on PowerStore
         </tr>
                             <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > hard_limit </td>
-                <td> int  </td>
-                <td></td>
-                <td></td>
-                <td></td>
-                <td>  <br> Hard limit of the user quota.  <br> No hard limit when set to 0.  </td>
-            </tr>
-                    <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=1 > soft_limit </td>
                 <td> int  </td>
                 <td></td>
@@ -7801,7 +8236,16 @@ Manage Tree Quotas and User Quotas on PowerStore
                 <td></td>
                 <td>  <br> Soft limit of the User/Tree quota.  <br> No Soft limit when set to 0.  </td>
             </tr>
-                    <tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > hard_limit </td>
+                <td> int  </td>
+                <td></td>
+                <td></td>
+                <td></td>
+                <td>  <br> Hard limit of the user quota.  <br> No hard limit when set to 0.  </td>
+            </tr>
+                                <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=1 > cap_unit </td>
                 <td> str  </td>
@@ -7810,7 +8254,63 @@ Manage Tree Quotas and User Quotas on PowerStore
                 <td> <ul> <li>GB</li>  <li>TB</li> </ul></td>
                 <td>  <br> Unit of storage for the hard and soft limits.  <br> This parameter is required if limit is specified.  </td>
             </tr>
-                                                                                                    </table>
+                                        <tr>
+            <td colspan=2 > state</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td> <ul> <li>absent</li>  <li>present</li> </ul></td>
+            <td> <br> Define whether the Quota should exist or not.  <br> Value present  indicates that the Quota should exist on the system.  <br> Value absent  indicates that the Quota should not exist on the system. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > array_ip</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td></td>
+            <td> <br> IP or FQDN of the PowerStore management system. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > verifycert</td>
+            <td> bool  </td>
+            <td> True </td>
+            <td></td>
+            <td> <ul> <li>True</li>  <li>False</li> </ul></td>
+            <td> <br> Boolean variable to specify whether to validate SSL certificate or not.  <br> True - indicates that the SSL certificate should be verified. Set the environment variable REQUESTS_CA_BUNDLE to the path of the SSL certificate.  <br> False - indicates that the SSL certificate should not be verified. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > user</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td></td>
+            <td> <br> The username of the PowerStore host. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > password</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td></td>
+            <td> <br> The password of the PowerStore host. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > timeout</td>
+            <td> int  </td>
+            <td></td>
+            <td> 120 </td>
+            <td></td>
+            <td> <br> Time after which the connection will get terminated.  <br> It is to be mentioned in seconds. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > port</td>
+            <td> int  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Port number for the PowerStore array.  <br> If not passed, it will take 443 as default. </td>
+        </tr>
+                                                    </table>
 
 ### Notes
 * Tree quota cannot be created at the root of the filesystem.
@@ -7913,7 +8413,7 @@ Manage Tree Quotas and User Quotas on PowerStore
         <th>Returned</th>
         <th width="100%">Description</th>
     </tr>
-                                    <tr>
+                                                                                            <tr>
             <td colspan=4 > changed </td>
             <td>  bool </td>
             <td> always </td>
@@ -7927,55 +8427,10 @@ Manage Tree Quotas and User Quotas on PowerStore
         </tr>
                             <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=3 > tree_quota_for_user_quota </td>
-                <td> complex </td>
+                <td colspan=3 > description </td>
+                <td> str </td>
                 <td>success</td>
-                <td> Additional Information of Tree Quota limits on which user quota exists. Only applicable for User Quotas. </td>
-            </tr>
-                                         <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=2 > hard_limit(cap_unit) </td>
-                    <td> int </td>
-                    <td>success</td>
-                    <td> Value of the Hard Limit imposed on the quota. </td>
-                </tr>
-                                             <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=2 > description </td>
-                    <td> str </td>
-                    <td>success</td>
-                    <td> Description of Tree Quota for user quota. </td>
-                </tr>
-                                             <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=2 > path </td>
-                    <td> str </td>
-                    <td>success</td>
-                    <td> The path on which the quota will be imposed. </td>
-                </tr>
-                                                            <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=3 > remaining_grace_period </td>
-                <td> int </td>
-                <td>success</td>
-                <td> The time period remaining after which the grace period will expire. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=3 > uid </td>
-                <td> int </td>
-                <td>success</td>
-                <td> The ID of the unix host for which user quota exists. Only applicable for user quotas. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=3 > soft_limit(cap_unit) </td>
-                <td> int </td>
-                <td>success</td>
-                <td> Value of the Soft Limit imposed on the quota. </td>
+                <td> Additional information about the tree quota. Only applicable for Tree Quotas. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
@@ -7987,26 +8442,10 @@ Manage Tree Quotas and User Quotas on PowerStore
                                          <tr>
                     <td class="elbow-placeholder">&nbsp;</td>
                     <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=2 > name </td>
-                    <td> str </td>
-                    <td>success</td>
-                    <td> Name of filesystem. </td>
-                </tr>
-                                             <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
                     <td colspan=2 > filesystem_type </td>
                     <td> str </td>
                     <td>success</td>
                     <td> Type of filesystem. </td>
-                </tr>
-                                             <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=2 > nas_server </td>
-                    <td> dict </td>
-                    <td>success</td>
-                    <td> nas_server of filesystem. </td>
                 </tr>
                                              <tr>
                     <td class="elbow-placeholder">&nbsp;</td>
@@ -8016,19 +8455,28 @@ Manage Tree Quotas and User Quotas on PowerStore
                     <td>success</td>
                     <td> ID of filesystem. </td>
                 </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=2 > name </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> Name of filesystem. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=2 > nas_server </td>
+                    <td> dict </td>
+                    <td>success</td>
+                    <td> nas_server of filesystem. </td>
+                </tr>
                                                             <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=3 > unix_name </td>
-                <td> str </td>
+                <td colspan=3 > hard_limit(cap_unit) </td>
+                <td> int </td>
                 <td>success</td>
-                <td> The Name of the unix host for which user quota exists. Only applicable for user quotas. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=3 > windows_sid </td>
-                <td> str </td>
-                <td>success</td>
-                <td> The SID of the windows host for which user quota exists. Only applicable for user quotas. </td>
+                <td> Value of the Hard Limit imposed on the quota. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
@@ -8039,10 +8487,24 @@ Manage Tree Quotas and User Quotas on PowerStore
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=3 > remaining_grace_period </td>
+                <td> int </td>
+                <td>success</td>
+                <td> The time period remaining after which the grace period will expire. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=3 > size_used </td>
                 <td> int </td>
                 <td>success</td>
                 <td> Size currently consumed by Tree/User on the filesystem. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=3 > soft_limit(cap_unit) </td>
+                <td> int </td>
+                <td>success</td>
+                <td> Value of the Soft Limit imposed on the quota. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
@@ -8060,6 +8522,58 @@ Manage Tree Quotas and User Quotas on PowerStore
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=3 > tree_quota_for_user_quota </td>
+                <td> complex </td>
+                <td>success</td>
+                <td> Additional Information of Tree Quota limits on which user quota exists. Only applicable for User Quotas. </td>
+            </tr>
+                                         <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=2 > description </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> Description of Tree Quota for user quota. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=2 > hard_limit(cap_unit) </td>
+                    <td> int </td>
+                    <td>success</td>
+                    <td> Value of the Hard Limit imposed on the quota. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=2 > path </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> The path on which the quota will be imposed. </td>
+                </tr>
+                                                            <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=3 > tree_quota_id </td>
+                <td> str </td>
+                <td>success</td>
+                <td> ID of the Tree Quota on which the specific User Quota exists. Only applicable for user quotas. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=3 > uid </td>
+                <td> int </td>
+                <td>success</td>
+                <td> The ID of the unix host for which user quota exists. Only applicable for user quotas. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=3 > unix_name </td>
+                <td> str </td>
+                <td>success</td>
+                <td> The Name of the unix host for which user quota exists. Only applicable for user quotas. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=3 > windows_name </td>
                 <td> str </td>
                 <td>success</td>
@@ -8067,26 +8581,12 @@ Manage Tree Quotas and User Quotas on PowerStore
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=3 > hard_limit(cap_unit) </td>
-                <td> int </td>
-                <td>success</td>
-                <td> Value of the Hard Limit imposed on the quota. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=3 > description </td>
+                <td colspan=3 > windows_sid </td>
                 <td> str </td>
                 <td>success</td>
-                <td> Additional information about the tree quota. Only applicable for Tree Quotas. </td>
+                <td> The SID of the windows host for which user quota exists. Only applicable for user quotas. </td>
             </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=3 > tree_quota_id </td>
-                <td> str </td>
-                <td>success</td>
-                <td> ID of the Tree Quota on which the specific User Quota exists. Only applicable for user quotas. </td>
-            </tr>
-                                                                                                </table>
+                                        </table>
 
 ### Authors
 * P Srinivas Rao (@srinivas-rao5) <ansible.team@dell.com>
@@ -8101,7 +8601,7 @@ Remote Support operations on a PowerStore storage system
  This module also supports modifying an existing Remote Support configuration. Verify a remote support configuration. You can send a test alert through the remote support configuration.
 
 ### Parameters
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        
 <table>
     <tr>
         <th colspan=2>Parameter</th>
@@ -8111,6 +8611,14 @@ Remote Support operations on a PowerStore storage system
         <th>Choices</th>
         <th width="80%">Description</th>
     </tr>
+                                                            <tr>
+            <td colspan=2 > remote_support_id</td>
+            <td> int  </td>
+            <td> True </td>
+            <td></td>
+            <td></td>
+            <td> <br> Unique identifier of the remote support configuration. </td>
+        </tr>
                     <tr>
             <td colspan=2 > support_type</td>
             <td> str  </td>
@@ -8120,76 +8628,47 @@ Remote Support operations on a PowerStore storage system
             <td> <br> The type of remote support that is configured.  <br> Mandatory for modify and verify operation.  <br> SRS_Gateway support_type is only supported for verify operation. </td>
         </tr>
                     <tr>
-            <td colspan=2 > is_icw_configured</td>
-            <td> bool  </td>
+            <td colspan=2 > remote_support_servers</td>
+            <td> list   <br> elements: dict </td>
             <td></td>
             <td></td>
             <td></td>
-            <td> <br> Client already configured ICW. </td>
+            <td> <br> One or two remote support servers. </td>
         </tr>
-                    <tr>
+                            <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > address </td>
+                <td> str  </td>
+                <td> True </td>
+                <td></td>
+                <td></td>
+                <td>  <br> Gateway server IP address (IPv4).  <br> The address is a mandatory key.  </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > port </td>
+                <td> int  </td>
+                <td></td>
+                <td></td>
+                <td></td>
+                <td>  <br> Gateway server port.  </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > is_primary </td>
+                <td> bool  </td>
+                <td></td>
+                <td></td>
+                <td></td>
+                <td>  <br> Indicates whether the server is acting as the primary.  <br> One server must be set to false when two servers are configured.  </td>
+            </tr>
+                                        <tr>
             <td colspan=2 > server_state</td>
             <td> str  </td>
             <td></td>
             <td></td>
             <td> <ul> <li>present-in-server</li>  <li>absent-in-server</li> </ul></td>
             <td> <br> Indicates the state of the remote-support_servers.  <br> Required with remote_support_servers. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > array_ip</td>
-            <td> str  </td>
-            <td> True </td>
-            <td></td>
-            <td></td>
-            <td> <br> IP or FQDN of the PowerStore management system. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > return_support_license_text</td>
-            <td> bool  </td>
-            <td></td>
-            <td> False </td>
-            <td></td>
-            <td> <br> Indicates whether to return support license agreement text or not. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > remote_support_id</td>
-            <td> int  </td>
-            <td> True </td>
-            <td></td>
-            <td></td>
-            <td> <br> Unique identifier of the remote support configuration. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > send_test_alert</td>
-            <td> bool  </td>
-            <td></td>
-            <td> False </td>
-            <td></td>
-            <td> <br> Indicates whether to send a test alert or not. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > is_cloudiq_enabled</td>
-            <td> bool  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Indicates whether support for CloudIQ is enabled. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > wait_for_completion</td>
-            <td> bool  </td>
-            <td></td>
-            <td> False </td>
-            <td></td>
-            <td> <br> Flag to indicate if the operation should be run synchronously or asynchronously. True signifies synchronous execution. By default, modify operation will run asynchronously. </td>
-        </tr>
-                    <tr>
-            <td colspan=2 > proxy_address</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Proxy server IP address (IPv4). </td>
         </tr>
                     <tr>
             <td colspan=2 > is_support_assist_license_accepted</td>
@@ -8200,20 +8679,36 @@ Remote Support operations on a PowerStore storage system
             <td> <br> Indicates whether user has accepted remote support license agreement before enabling the Support Assist on the system for the first time. </td>
         </tr>
                     <tr>
-            <td colspan=2 > verifycert</td>
+            <td colspan=2 > is_cloudiq_enabled</td>
             <td> bool  </td>
-            <td> True </td>
             <td></td>
-            <td> <ul> <li>True</li>  <li>False</li> </ul></td>
-            <td> <br> Boolean variable to specify whether to validate SSL certificate or not.  <br> True - indicates that the SSL certificate should be verified. Set the environment variable REQUESTS_CA_BUNDLE to the path of the SSL certificate.  <br> False - indicates that the SSL certificate should not be verified. </td>
+            <td></td>
+            <td></td>
+            <td> <br> Indicates whether support for CloudIQ is enabled. </td>
         </tr>
                     <tr>
-            <td colspan=2 > password</td>
+            <td colspan=2 > is_rsc_enabled</td>
+            <td> bool  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Indicates whether support for Remote Service Credentials is enabled. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > proxy_address</td>
             <td> str  </td>
-            <td> True </td>
             <td></td>
             <td></td>
-            <td> <br> The password of the PowerStore host. </td>
+            <td></td>
+            <td> <br> Proxy server IP address (IPv4). </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > proxy_port</td>
+            <td> int  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Proxy server port number. </td>
         </tr>
                     <tr>
             <td colspan=2 > proxy_username</td>
@@ -8232,49 +8727,14 @@ Remote Support operations on a PowerStore storage system
             <td> <br> Password for proxy server access. </td>
         </tr>
                     <tr>
-            <td colspan=2 > is_rsc_enabled</td>
+            <td colspan=2 > is_icw_configured</td>
             <td> bool  </td>
             <td></td>
             <td></td>
             <td></td>
-            <td> <br> Indicates whether support for Remote Service Credentials is enabled. </td>
+            <td> <br> Client already configured ICW. </td>
         </tr>
                     <tr>
-            <td colspan=2 > remote_support_servers</td>
-            <td> list   <br> elements: dict </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> One or two remote support servers. </td>
-        </tr>
-                            <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > port </td>
-                <td> int  </td>
-                <td></td>
-                <td></td>
-                <td></td>
-                <td>  <br> Gateway server port.  </td>
-            </tr>
-                    <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > address </td>
-                <td> str  </td>
-                <td> True </td>
-                <td></td>
-                <td></td>
-                <td>  <br> Gateway server IP address (IPv4).  <br> The address is a mandatory key.  </td>
-            </tr>
-                    <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > is_primary </td>
-                <td> bool  </td>
-                <td></td>
-                <td></td>
-                <td></td>
-                <td>  <br> Indicates whether the server is acting as the primary.  <br> One server must be set to false when two servers are configured.  </td>
-            </tr>
-                            <tr>
             <td colspan=2 > verify_connection</td>
             <td> bool  </td>
             <td></td>
@@ -8283,28 +8743,28 @@ Remote Support operations on a PowerStore storage system
             <td> <br> Indicates whether to perform the verify call or not. </td>
         </tr>
                     <tr>
-            <td colspan=2 > timeout</td>
-            <td> int  </td>
+            <td colspan=2 > send_test_alert</td>
+            <td> bool  </td>
             <td></td>
-            <td> 120 </td>
+            <td> False </td>
             <td></td>
-            <td> <br> Time after which the connection will get terminated.  <br> It is to be mentioned in seconds. </td>
+            <td> <br> Indicates whether to send a test alert or not. </td>
         </tr>
                     <tr>
-            <td colspan=2 > user</td>
-            <td> str  </td>
-            <td> True </td>
+            <td colspan=2 > wait_for_completion</td>
+            <td> bool  </td>
             <td></td>
+            <td> False </td>
             <td></td>
-            <td> <br> The username of the PowerStore host. </td>
+            <td> <br> Flag to indicate if the operation should be run synchronously or asynchronously. True signifies synchronous execution. By default, modify operation will run asynchronously. </td>
         </tr>
                     <tr>
-            <td colspan=2 > proxy_port</td>
-            <td> int  </td>
+            <td colspan=2 > return_support_license_text</td>
+            <td> bool  </td>
             <td></td>
+            <td> False </td>
             <td></td>
-            <td></td>
-            <td> <br> Proxy server port number. </td>
+            <td> <br> Indicates whether to return support license agreement text or not. </td>
         </tr>
                     <tr>
             <td colspan=2 > state</td>
@@ -8315,6 +8775,46 @@ Remote Support operations on a PowerStore storage system
             <td> <br> The state of the remote support configuration after the task is performed.  <br> For Delete operation only, it should be set to "absent".  <br> For get/modify operation it should be set to "present". </td>
         </tr>
                     <tr>
+            <td colspan=2 > array_ip</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td></td>
+            <td> <br> IP or FQDN of the PowerStore management system. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > verifycert</td>
+            <td> bool  </td>
+            <td> True </td>
+            <td></td>
+            <td> <ul> <li>True</li>  <li>False</li> </ul></td>
+            <td> <br> Boolean variable to specify whether to validate SSL certificate or not.  <br> True - indicates that the SSL certificate should be verified. Set the environment variable REQUESTS_CA_BUNDLE to the path of the SSL certificate.  <br> False - indicates that the SSL certificate should not be verified. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > user</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td></td>
+            <td> <br> The username of the PowerStore host. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > password</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td></td>
+            <td> <br> The password of the PowerStore host. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > timeout</td>
+            <td> int  </td>
+            <td></td>
+            <td> 120 </td>
+            <td></td>
+            <td> <br> Time after which the connection will get terminated.  <br> It is to be mentioned in seconds. </td>
+        </tr>
+                    <tr>
             <td colspan=2 > port</td>
             <td> int  </td>
             <td></td>
@@ -8322,7 +8822,7 @@ Remote Support operations on a PowerStore storage system
             <td></td>
             <td> <br> Port number for the PowerStore array.  <br> If not passed, it will take 443 as default. </td>
         </tr>
-                                                                                            </table>
+                                                    </table>
 
 ### Notes
 * Creation and deletion of remote support configuration is not supported.
@@ -8409,13 +8909,26 @@ Remote Support operations on a PowerStore storage system
         <th>Returned</th>
         <th width="100%">Description</th>
     </tr>
-                                    <tr>
+                                                                                            <tr>
             <td colspan=3 > changed </td>
             <td>  bool </td>
             <td> always </td>
             <td> Whether or not the resource has changed. </td>
         </tr>
                     <tr>
+            <td colspan=3 > job_details </td>
+            <td>  complex </td>
+            <td> When asynchronous task is performed. </td>
+            <td> The job details. </td>
+        </tr>
+                            <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > id </td>
+                <td> str </td>
+                <td>success</td>
+                <td> The ID of the job. </td>
+            </tr>
+                                        <tr>
             <td colspan=3 > remote_support_details </td>
             <td>  complex </td>
             <td> When remote support configuration exists. </td>
@@ -8423,10 +8936,10 @@ Remote Support operations on a PowerStore storage system
         </tr>
                             <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > proxy_username </td>
-                <td> str </td>
+                <td colspan=2 > id </td>
+                <td> int </td>
                 <td>success</td>
-                <td> User name for proxy server access. </td>
+                <td> Unique identifier of remote support configuration. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
@@ -8437,58 +8950,12 @@ Remote Support operations on a PowerStore storage system
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > support_assist_license_agreement_text </td>
-                <td> str </td>
-                <td>success</td>
-                <td> The support assist license agreement text. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=2 > is_rsc_enabled </td>
                 <td> bool </td>
                 <td>success</td>
                 <td> Indicates whether support for Remote Service Credentials is enabled. </td>
             </tr>
                                 <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > remote_support_servers </td>
-                <td> complex </td>
-                <td>success</td>
-                <td> ['Details of two remote support servers.'] </td>
-            </tr>
-                                         <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=1 > port </td>
-                    <td> int </td>
-                    <td>success</td>
-                    <td> Gateway server port. </td>
-                </tr>
-                                             <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=1 > id </td>
-                    <td> str </td>
-                    <td>success</td>
-                    <td> Unique identifier of the remote support server. </td>
-                </tr>
-                                             <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=1 > address </td>
-                    <td> str </td>
-                    <td>success</td>
-                    <td> Gateway server IP address (IPv4). </td>
-                </tr>
-                                             <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=1 > is_primary </td>
-                    <td> bool </td>
-                    <td>success</td>
-                    <td> Indicates whether the server is acting as the primary. </td>
-                </tr>
-                                                            <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=2 > is_support_assist_license_accepted </td>
                 <td> bool </td>
@@ -8504,20 +8971,6 @@ Remote Support operations on a PowerStore storage system
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > type </td>
-                <td> str </td>
-                <td>success</td>
-                <td> The type of remote support that is configured. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > id </td>
-                <td> int </td>
-                <td>success</td>
-                <td> Unique identifier of remote support configuration. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=2 > proxy_password </td>
                 <td> str </td>
                 <td>success</td>
@@ -8530,20 +8983,67 @@ Remote Support operations on a PowerStore storage system
                 <td>success</td>
                 <td> Proxy server port number. </td>
             </tr>
-                                        <tr>
-            <td colspan=3 > job_details </td>
-            <td>  complex </td>
-            <td> When asynchronous task is performed. </td>
-            <td> The job details. </td>
-        </tr>
-                            <tr>
+                                <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > id </td>
+                <td colspan=2 > proxy_username </td>
                 <td> str </td>
                 <td>success</td>
-                <td> The ID of the job. </td>
+                <td> User name for proxy server access. </td>
             </tr>
-                                                                                                </table>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > remote_support_servers </td>
+                <td> complex </td>
+                <td>success</td>
+                <td> ['Details of two remote support servers.'] </td>
+            </tr>
+                                         <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=1 > address </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> Gateway server IP address (IPv4). </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=1 > id </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> Unique identifier of the remote support server. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=1 > is_primary </td>
+                    <td> bool </td>
+                    <td>success</td>
+                    <td> Indicates whether the server is acting as the primary. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=1 > port </td>
+                    <td> int </td>
+                    <td>success</td>
+                    <td> Gateway server port. </td>
+                </tr>
+                                                            <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > support_assist_license_agreement_text </td>
+                <td> str </td>
+                <td>success</td>
+                <td> The support assist license agreement text. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > type </td>
+                <td> str </td>
+                <td>success</td>
+                <td> The type of remote support that is configured. </td>
+            </tr>
+                                        </table>
 
 ### Authors
 * Trisha Datta (@Trisha_Datta) <ansible.team@dell.com>
@@ -8567,13 +9067,13 @@ Remote Support Contact operations on a PowerStore storage system
         <th>Choices</th>
         <th width="80%">Description</th>
     </tr>
-                    <tr>
-            <td colspan=1 > array_ip</td>
-            <td> str  </td>
+                                                            <tr>
+            <td colspan=1 > contact_id</td>
+            <td> int  </td>
             <td> True </td>
             <td></td>
             <td></td>
-            <td> <br> IP or FQDN of the PowerStore management system. </td>
+            <td> <br> Unique identifier of the remote support contact. </td>
         </tr>
                     <tr>
             <td colspan=1 > first_name</td>
@@ -8584,20 +9084,12 @@ Remote Support Contact operations on a PowerStore storage system
             <td> <br> The first name of the support contact for this system. </td>
         </tr>
                     <tr>
-            <td colspan=1 > port</td>
-            <td> int  </td>
+            <td colspan=1 > last_name</td>
+            <td> str  </td>
             <td></td>
             <td></td>
             <td></td>
-            <td> <br> Port number for the PowerStore array.  <br> If not passed, it will take 443 as default. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > contact_id</td>
-            <td> int  </td>
-            <td> True </td>
-            <td></td>
-            <td></td>
-            <td> <br> Unique identifier of the remote support contact. </td>
+            <td> <br> The last name of the support contact for this system. </td>
         </tr>
                     <tr>
             <td colspan=1 > phone</td>
@@ -8608,20 +9100,12 @@ Remote Support Contact operations on a PowerStore storage system
             <td> <br> The phone number of this support contact for this system. </td>
         </tr>
                     <tr>
-            <td colspan=1 > timeout</td>
-            <td> int  </td>
-            <td></td>
-            <td> 120 </td>
-            <td></td>
-            <td> <br> Time after which the connection will get terminated.  <br> It is to be mentioned in seconds. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > user</td>
+            <td colspan=1 > email</td>
             <td> str  </td>
-            <td> True </td>
             <td></td>
             <td></td>
-            <td> <br> The username of the PowerStore host. </td>
+            <td></td>
+            <td> <br> The email address of the support contact for this system. </td>
         </tr>
                     <tr>
             <td colspan=1 > state</td>
@@ -8632,6 +9116,14 @@ Remote Support Contact operations on a PowerStore storage system
             <td> <br> The state of the remote support contact after the task is performed.  <br> For Delete operation only, it should be set to "absent".  <br> For get/modify operation it should be set to "present". </td>
         </tr>
                     <tr>
+            <td colspan=1 > array_ip</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td></td>
+            <td> <br> IP or FQDN of the PowerStore management system. </td>
+        </tr>
+                    <tr>
             <td colspan=1 > verifycert</td>
             <td> bool  </td>
             <td> True </td>
@@ -8640,12 +9132,12 @@ Remote Support Contact operations on a PowerStore storage system
             <td> <br> Boolean variable to specify whether to validate SSL certificate or not.  <br> True - indicates that the SSL certificate should be verified. Set the environment variable REQUESTS_CA_BUNDLE to the path of the SSL certificate.  <br> False - indicates that the SSL certificate should not be verified. </td>
         </tr>
                     <tr>
-            <td colspan=1 > email</td>
+            <td colspan=1 > user</td>
             <td> str  </td>
+            <td> True </td>
             <td></td>
             <td></td>
-            <td></td>
-            <td> <br> The email address of the support contact for this system. </td>
+            <td> <br> The username of the PowerStore host. </td>
         </tr>
                     <tr>
             <td colspan=1 > password</td>
@@ -8656,14 +9148,22 @@ Remote Support Contact operations on a PowerStore storage system
             <td> <br> The password of the PowerStore host. </td>
         </tr>
                     <tr>
-            <td colspan=1 > last_name</td>
-            <td> str  </td>
+            <td colspan=1 > timeout</td>
+            <td> int  </td>
             <td></td>
+            <td> 120 </td>
             <td></td>
-            <td></td>
-            <td> <br> The last name of the support contact for this system. </td>
+            <td> <br> Time after which the connection will get terminated.  <br> It is to be mentioned in seconds. </td>
         </tr>
-                                                                                            </table>
+                    <tr>
+            <td colspan=1 > port</td>
+            <td> int  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Port number for the PowerStore array.  <br> If not passed, it will take 443 as default. </td>
+        </tr>
+                                                    </table>
 
 ### Notes
 * Creation and deletion of remote support contact is not supported.
@@ -8705,13 +9205,26 @@ Remote Support Contact operations on a PowerStore storage system
         <th>Returned</th>
         <th width="100%">Description</th>
     </tr>
-                                    <tr>
+                                                                                            <tr>
+            <td colspan=2 > changed </td>
+            <td>  bool </td>
+            <td> always </td>
+            <td> Whether or not the resource has changed. </td>
+        </tr>
+                    <tr>
             <td colspan=2 > remote_support_contact_details </td>
             <td>  complex </td>
             <td> When remote support contact exists. </td>
             <td> Details of the remote support contact. </td>
         </tr>
                             <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > email </td>
+                <td> str </td>
+                <td>success</td>
+                <td> The email address of the support contact for this system. </td>
+            </tr>
+                                <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=1 > first_name </td>
                 <td> str </td>
@@ -8739,20 +9252,7 @@ Remote Support Contact operations on a PowerStore storage system
                 <td>success</td>
                 <td> The phone number of this support contact for this system. </td>
             </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > email </td>
-                <td> str </td>
-                <td>success</td>
-                <td> The email address of the support contact for this system. </td>
-            </tr>
-                                        <tr>
-            <td colspan=2 > changed </td>
-            <td>  bool </td>
-            <td> always </td>
-            <td> Whether or not the resource has changed. </td>
-        </tr>
-                                                                            </table>
+                                        </table>
 
 ### Authors
 * Trisha Datta (@Trisha_Datta) <ansible.team@dell.com>
@@ -8777,7 +9277,7 @@ Remote system operations on a PowerStore storage system
         <th>Choices</th>
         <th width="80%">Description</th>
     </tr>
-                    <tr>
+                                                            <tr>
             <td colspan=1 > remote_name</td>
             <td> str  </td>
             <td></td>
@@ -8786,52 +9286,20 @@ Remote system operations on a PowerStore storage system
             <td> <br> Name of the remote system.  <br> Parameter remote_name cannot be mentioned during addition of a new remote system. </td>
         </tr>
                     <tr>
-            <td colspan=1 > new_remote_address</td>
+            <td colspan=1 > remote_id</td>
             <td> str  </td>
             <td></td>
             <td></td>
             <td></td>
-            <td> <br> New management IP of the remote system. </td>
+            <td> <br> ID of the remote system.  <br> ID for the remote system is autogenerated, cannot be passed during creation of a remote system.  <br> Parameter remote_id and remote_address are mutually exclusive. </td>
         </tr>
                     <tr>
-            <td colspan=1 > remote_address</td>
+            <td colspan=1 > remote_user</td>
             <td> str  </td>
             <td></td>
             <td></td>
             <td></td>
-            <td> <br> Management IP of the remote system.  <br> Parameter remote_id and remote_address are mutually exclusive. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > network_latency</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td> <ul> <li>Low</li>  <li>High</li> </ul></td>
-            <td> <br> Replication traffic can be tuned for higher efficiency depending on the expected network latency.  <br> Setting to low will have latency of less than five milliseconds.  <br> Setting to high will have latency of more than five milliseconds. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > state</td>
-            <td> str  </td>
-            <td> True </td>
-            <td></td>
-            <td> <ul> <li>present</li>  <li>absent</li> </ul></td>
-            <td> <br> The state of the remote system after the task is performed.  <br> For Delete operation only, it should be set to "absent".  <br> For all Create, Modify or Get details operations it should be set to "present". </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > remote_port</td>
-            <td> int  </td>
-            <td></td>
-            <td> 443 </td>
-            <td></td>
-            <td> <br> Remote system's port number.  <br> It can be mentioned only during creation of the remote system. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > port</td>
-            <td> int  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Port number for the PowerStore array.  <br> If not passed, it will take 443 as default. </td>
+            <td> <br> Username used in basic authentication to remote PowerStore cluster.  <br> It can be mentioned only during creation of the remote system. </td>
         </tr>
                     <tr>
             <td colspan=1 > remote_password</td>
@@ -8842,20 +9310,44 @@ Remote system operations on a PowerStore storage system
             <td> <br> Password used in basic authentication to remote PowerStore cluster.  <br> It can be mentioned only during creation of the remote system. </td>
         </tr>
                     <tr>
-            <td colspan=1 > timeout</td>
-            <td> int  </td>
+            <td colspan=1 > remote_address</td>
+            <td> str  </td>
             <td></td>
-            <td> 120 </td>
             <td></td>
-            <td> <br> Time after which the connection will get terminated.  <br> It is to be mentioned in seconds. </td>
+            <td></td>
+            <td> <br> Management IP of the remote system.  <br> Parameter remote_id and remote_address are mutually exclusive. </td>
         </tr>
                     <tr>
-            <td colspan=1 > user</td>
+            <td colspan=1 > new_remote_address</td>
             <td> str  </td>
-            <td> True </td>
             <td></td>
             <td></td>
-            <td> <br> The username of the PowerStore host. </td>
+            <td></td>
+            <td> <br> New management IP of the remote system. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > remote_port</td>
+            <td> int  </td>
+            <td></td>
+            <td> 443 </td>
+            <td></td>
+            <td> <br> Remote system's port number.  <br> It can be mentioned only during creation of the remote system. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > description</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Additional information about the remote system.  <br> To remove the description empty string is to be passed. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > network_latency</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td> <ul> <li>Low</li>  <li>High</li> </ul></td>
+            <td> <br> Replication traffic can be tuned for higher efficiency depending on the expected network latency.  <br> Setting to low will have latency of less than five milliseconds.  <br> Setting to high will have latency of more than five milliseconds. </td>
         </tr>
                     <tr>
             <td colspan=1 > wait_for_completion</td>
@@ -8864,6 +9356,14 @@ Remote system operations on a PowerStore storage system
             <td> False </td>
             <td> <ul> <li>True</li>  <li>False</li> </ul></td>
             <td> <br> Flag to indicate if the operation should be run synchronously or asynchronously.  <br> True signifies synchronous execution.  <br> By default, modify and delete operation will run asynchronously. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > state</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td> <ul> <li>present</li>  <li>absent</li> </ul></td>
+            <td> <br> The state of the remote system after the task is performed.  <br> For Delete operation only, it should be set to "absent".  <br> For all Create, Modify or Get details operations it should be set to "present". </td>
         </tr>
                     <tr>
             <td colspan=1 > array_ip</td>
@@ -8882,12 +9382,12 @@ Remote system operations on a PowerStore storage system
             <td> <br> Boolean variable to specify whether to validate SSL certificate or not.  <br> True - indicates that the SSL certificate should be verified. Set the environment variable REQUESTS_CA_BUNDLE to the path of the SSL certificate.  <br> False - indicates that the SSL certificate should not be verified. </td>
         </tr>
                     <tr>
-            <td colspan=1 > remote_user</td>
+            <td colspan=1 > user</td>
             <td> str  </td>
+            <td> True </td>
             <td></td>
             <td></td>
-            <td></td>
-            <td> <br> Username used in basic authentication to remote PowerStore cluster.  <br> It can be mentioned only during creation of the remote system. </td>
+            <td> <br> The username of the PowerStore host. </td>
         </tr>
                     <tr>
             <td colspan=1 > password</td>
@@ -8898,22 +9398,22 @@ Remote system operations on a PowerStore storage system
             <td> <br> The password of the PowerStore host. </td>
         </tr>
                     <tr>
-            <td colspan=1 > description</td>
-            <td> str  </td>
+            <td colspan=1 > timeout</td>
+            <td> int  </td>
             <td></td>
+            <td> 120 </td>
             <td></td>
-            <td></td>
-            <td> <br> Additional information about the remote system.  <br> To remove the description empty string is to be passed. </td>
+            <td> <br> Time after which the connection will get terminated.  <br> It is to be mentioned in seconds. </td>
         </tr>
                     <tr>
-            <td colspan=1 > remote_id</td>
-            <td> str  </td>
+            <td colspan=1 > port</td>
+            <td> int  </td>
             <td></td>
             <td></td>
             <td></td>
-            <td> <br> ID of the remote system.  <br> ID for the remote system is autogenerated, cannot be passed during creation of a remote system.  <br> Parameter remote_id and remote_address are mutually exclusive. </td>
+            <td> <br> Port number for the PowerStore array.  <br> If not passed, it will take 443 as default. </td>
         </tr>
-                                                                                            </table>
+                                                    </table>
 
 ### Notes
 * The module support allows create/delete/update only for remote PowerStore arrays.
@@ -8982,143 +9482,7 @@ Remote system operations on a PowerStore storage system
         <th>Returned</th>
         <th width="100%">Description</th>
     </tr>
-                                    <tr>
-            <td colspan=3 > remote_system_details </td>
-            <td>  complex </td>
-            <td> When remote system exists </td>
-            <td> Details of the remote system. </td>
-        </tr>
-                            <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > discovery_chap_mode </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Challenge Handshake Authentication Protocol (CHAP) statu. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > serial_number </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Serial number of the remote system instance. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > data_connections </td>
-                <td> complex </td>
-                <td>success</td>
-                <td> ['List of data connections from each appliance in the local cluster to iSCSI target IP address.'] </td>
-            </tr>
-                                         <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=1 > status </td>
-                    <td> str </td>
-                    <td>success</td>
-                    <td> Possible transit connection statuses. </td>
-                </tr>
-                                             <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=1 > target_address </td>
-                    <td> str </td>
-                    <td>success</td>
-                    <td> Target address from the remote system. </td>
-                </tr>
-                                             <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=1 > initiator_address </td>
-                    <td> str </td>
-                    <td>success</td>
-                    <td> Initiating address from the local node. </td>
-                </tr>
-                                             <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=1 > node_id </td>
-                    <td> str </td>
-                    <td>success</td>
-                    <td> Unique identifier of the local, initiating node. </td>
-                </tr>
-                                                            <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > data_network_latency </td>
-                <td> str </td>
-                <td>success</td>
-                <td> ['Network latency choices for a remote system. Replication traffic can be tuned for higher efficiency depending on the expected network latency.', 'This will only be used when the remote system type is PowerStore.'] </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > management_address </td>
-                <td> str </td>
-                <td>success</td>
-                <td> The management cluster IP address of the remote system. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > user_name </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Username used to access the non-PowerStore remote systems. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > name </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Name of the remote system. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > version </td>
-                <td> str </td>
-                <td>success</td>
-                <td> ['Version of the remote system.', 'It was added in PowerStore version 2.0.0.0.'] </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > data_connection_state </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Data connection states of a remote system. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > id </td>
-                <td> str </td>
-                <td>success</td>
-                <td> The system generated ID of the remote system. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > state </td>
-                <td> str </td>
-                <td>success</td>
-                <td> ['Possible remote system states.', 'OK, Normal conditions.', 'Update_Needed, Verify and update needed to handle network configuration changes on the systems.', 'Management_Connection_Lost, Management connection to the remote peer is lost.'] </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > session_chap_mode </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Challenge Handshake Authentication Protocol (CHAP) status. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > type </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Remote system connection type between the local system. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > description </td>
-                <td> str </td>
-                <td>success</td>
-                <td> User-specified description of the remote system instance. </td>
-            </tr>
-                                        <tr>
+                                                                                            <tr>
             <td colspan=3 > changed </td>
             <td>  bool </td>
             <td> always </td>
@@ -9137,7 +9501,143 @@ Remote system operations on a PowerStore storage system
                 <td>success</td>
                 <td> The id of the job. </td>
             </tr>
-                                                                                                </table>
+                                        <tr>
+            <td colspan=3 > remote_system_details </td>
+            <td>  complex </td>
+            <td> When remote system exists </td>
+            <td> Details of the remote system. </td>
+        </tr>
+                            <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > data_connection_state </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Data connection states of a remote system. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > data_connections </td>
+                <td> complex </td>
+                <td>success</td>
+                <td> ['List of data connections from each appliance in the local cluster to iSCSI target IP address.'] </td>
+            </tr>
+                                         <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=1 > initiator_address </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> Initiating address from the local node. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=1 > node_id </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> Unique identifier of the local, initiating node. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=1 > status </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> Possible transit connection statuses. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=1 > target_address </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> Target address from the remote system. </td>
+                </tr>
+                                                            <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > data_network_latency </td>
+                <td> str </td>
+                <td>success</td>
+                <td> ['Network latency choices for a remote system. Replication traffic can be tuned for higher efficiency depending on the expected network latency.', 'This will only be used when the remote system type is PowerStore.'] </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > description </td>
+                <td> str </td>
+                <td>success</td>
+                <td> User-specified description of the remote system instance. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > discovery_chap_mode </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Challenge Handshake Authentication Protocol (CHAP) statu. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > id </td>
+                <td> str </td>
+                <td>success</td>
+                <td> The system generated ID of the remote system. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > management_address </td>
+                <td> str </td>
+                <td>success</td>
+                <td> The management cluster IP address of the remote system. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > name </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Name of the remote system. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > serial_number </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Serial number of the remote system instance. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > session_chap_mode </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Challenge Handshake Authentication Protocol (CHAP) status. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > state </td>
+                <td> str </td>
+                <td>success</td>
+                <td> ['Possible remote system states.', 'OK, Normal conditions.', 'Update_Needed, Verify and update needed to handle network configuration changes on the systems.', 'Management_Connection_Lost, Management connection to the remote peer is lost.'] </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > type </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Remote system connection type between the local system. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > user_name </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Username used to access the non-PowerStore remote systems. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > version </td>
+                <td> str </td>
+                <td>success</td>
+                <td> ['Version of the remote system.', 'It was added in PowerStore version 2.0.0.0.'] </td>
+            </tr>
+                                        </table>
 
 ### Authors
 * P Srinivas Rao (@srinivas-rao5) <ansible.team@dell.com>
@@ -9162,77 +9662,13 @@ Replication rule operations on a PowerStore storage system
         <th>Choices</th>
         <th width="80%">Description</th>
     </tr>
-                    <tr>
-            <td colspan=1 > timeout</td>
-            <td> int  </td>
-            <td></td>
-            <td> 120 </td>
-            <td></td>
-            <td> <br> Time after which the connection will get terminated.  <br> It is to be mentioned in seconds. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > rpo</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td> <ul> <li>Five_Minutes</li>  <li>Fifteen_Minutes</li>  <li>Thirty_Minutes</li>  <li>One_Hour</li>  <li>Six_Hours</li>  <li>Twelve_Hours</li>  <li>One_Day</li> </ul></td>
-            <td> <br> Recovery point objective (RPO), which is the acceptable amount of data, measured in units of time, that may be lost in case of a failure. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > array_ip</td>
-            <td> str  </td>
-            <td> True </td>
-            <td></td>
-            <td></td>
-            <td> <br> IP or FQDN of the PowerStore management system. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > alert_threshold</td>
-            <td> int  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Acceptable delay between the expected and actual replication sync intervals. The system generates an alert if the delay between the expected and actual sync exceeds this threshold.  <br> During creation, if not passed, then by default one RPO in minutes will be passed.  <br> The range of integers supported are in between 0 and 1440 (inclusive of both). </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > port</td>
-            <td> int  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Port number for the PowerStore array.  <br> If not passed, it will take 443 as default. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > new_name</td>
+                                                            <tr>
+            <td colspan=1 > replication_rule_name</td>
             <td> str  </td>
             <td></td>
             <td></td>
             <td></td>
-            <td> <br> New name of the replication rule.  <br> Used for renaming a replication rule. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > remote_system</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> ID or name of the remote system to which this rule will replicate the associated resources. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > user</td>
-            <td> str  </td>
-            <td> True </td>
-            <td></td>
-            <td></td>
-            <td> <br> The username of the PowerStore host. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > remote_system_address</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> The management IPv4 address of the remote system.  <br> It is required in case the remote system name passed in remote_system parameter is not unique on the PowerStore Array.  <br> If ID of the remote system is passed then no need to pass remote_system_address. </td>
+            <td> <br> Name of the replication rule.  <br> Required during creation of a replication rule.  <br> Parameter replication_rule_name and replication_rule_id are mutually exclusive. </td>
         </tr>
                     <tr>
             <td colspan=1 > replication_rule_id</td>
@@ -9243,20 +9679,44 @@ Replication rule operations on a PowerStore storage system
             <td> <br> ID of the replication rule.  <br> ID for the rule is autogenerated, cannot be passed during creation of a replication rule.  <br> Parameter replication_rule_name and replication_rule_id are mutually exclusive. </td>
         </tr>
                     <tr>
-            <td colspan=1 > replication_rule_name</td>
+            <td colspan=1 > new_name</td>
             <td> str  </td>
             <td></td>
             <td></td>
             <td></td>
-            <td> <br> Name of the replication rule.  <br> Required during creation of a replication rule.  <br> Parameter replication_rule_name and replication_rule_id are mutually exclusive. </td>
+            <td> <br> New name of the replication rule.  <br> Used for renaming a replication rule. </td>
         </tr>
                     <tr>
-            <td colspan=1 > verifycert</td>
-            <td> bool  </td>
-            <td> True </td>
+            <td colspan=1 > rpo</td>
+            <td> str  </td>
             <td></td>
-            <td> <ul> <li>True</li>  <li>False</li> </ul></td>
-            <td> <br> Boolean variable to specify whether to validate SSL certificate or not.  <br> True - indicates that the SSL certificate should be verified. Set the environment variable REQUESTS_CA_BUNDLE to the path of the SSL certificate.  <br> False - indicates that the SSL certificate should not be verified. </td>
+            <td></td>
+            <td> <ul> <li>Five_Minutes</li>  <li>Fifteen_Minutes</li>  <li>Thirty_Minutes</li>  <li>One_Hour</li>  <li>Six_Hours</li>  <li>Twelve_Hours</li>  <li>One_Day</li> </ul></td>
+            <td> <br> Recovery point objective (RPO), which is the acceptable amount of data, measured in units of time, that may be lost in case of a failure. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > alert_threshold</td>
+            <td> int  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Acceptable delay between the expected and actual replication sync intervals. The system generates an alert if the delay between the expected and actual sync exceeds this threshold.  <br> During creation, if not passed, then by default one RPO in minutes will be passed.  <br> The range of integers supported are in between 0 and 1440 (inclusive of both). </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > remote_system</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> ID or name of the remote system to which this rule will replicate the associated resources. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > remote_system_address</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> The management IPv4 address of the remote system.  <br> It is required in case the remote system name passed in remote_system parameter is not unique on the PowerStore Array.  <br> If ID of the remote system is passed then no need to pass remote_system_address. </td>
         </tr>
                     <tr>
             <td colspan=1 > state</td>
@@ -9267,6 +9727,30 @@ Replication rule operations on a PowerStore storage system
             <td> <br> The state of the replication rule after the task is performed.  <br> For Delete operation only, it should be set to "absent".  <br> For all Create, Modify or Get details operations it should be set to "present". </td>
         </tr>
                     <tr>
+            <td colspan=1 > array_ip</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td></td>
+            <td> <br> IP or FQDN of the PowerStore management system. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > verifycert</td>
+            <td> bool  </td>
+            <td> True </td>
+            <td></td>
+            <td> <ul> <li>True</li>  <li>False</li> </ul></td>
+            <td> <br> Boolean variable to specify whether to validate SSL certificate or not.  <br> True - indicates that the SSL certificate should be verified. Set the environment variable REQUESTS_CA_BUNDLE to the path of the SSL certificate.  <br> False - indicates that the SSL certificate should not be verified. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > user</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td></td>
+            <td> <br> The username of the PowerStore host. </td>
+        </tr>
+                    <tr>
             <td colspan=1 > password</td>
             <td> str  </td>
             <td> True </td>
@@ -9274,7 +9758,23 @@ Replication rule operations on a PowerStore storage system
             <td></td>
             <td> <br> The password of the PowerStore host. </td>
         </tr>
-                                                                                            </table>
+                    <tr>
+            <td colspan=1 > timeout</td>
+            <td> int  </td>
+            <td></td>
+            <td> 120 </td>
+            <td></td>
+            <td> <br> Time after which the connection will get terminated.  <br> It is to be mentioned in seconds. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > port</td>
+            <td> int  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Port number for the PowerStore array.  <br> If not passed, it will take 443 as default. </td>
+        </tr>
+                                                    </table>
 
 ### Notes
 * The check_mode is not supported.
@@ -9335,7 +9835,7 @@ Replication rule operations on a PowerStore storage system
         <th>Returned</th>
         <th width="100%">Description</th>
     </tr>
-                                    <tr>
+                                                                                            <tr>
             <td colspan=2 > changed </td>
             <td>  bool </td>
             <td> always </td>
@@ -9349,17 +9849,10 @@ Replication rule operations on a PowerStore storage system
         </tr>
                             <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > name </td>
-                <td> str </td>
+                <td colspan=1 > alert_threshold </td>
+                <td> int </td>
                 <td>success</td>
-                <td> Name of the replication rule. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > rpo </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Recovery point objective (RPO), which is the acceptable amount of data, measured in units of time, that may be lost in case of a failure. </td>
+                <td> Acceptable delay in minutes between the expected and actual replication sync intervals. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
@@ -9370,17 +9863,17 @@ Replication rule operations on a PowerStore storage system
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > name </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Name of the replication rule. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=1 > remote_system_id </td>
                 <td> str </td>
                 <td>success</td>
                 <td> Unique identifier of the remote system to which this rule will replicate the associated resources. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > alert_threshold </td>
-                <td> int </td>
-                <td>success</td>
-                <td> Acceptable delay in minutes between the expected and actual replication sync intervals. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
@@ -9389,7 +9882,14 @@ Replication rule operations on a PowerStore storage system
                 <td>success</td>
                 <td> Name of the remote system to which this rule will replicate the associated resources. </td>
             </tr>
-                                                                                                </table>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > rpo </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Recovery point objective (RPO), which is the acceptable amount of data, measured in units of time, that may be lost in case of a failure. </td>
+            </tr>
+                                        </table>
 
 ### Authors
 * P Srinivas Rao (@srinivas-rao5) <ansible.team@dell.com>
@@ -9404,7 +9904,7 @@ Replication session operations on a PowerStore storage system
  This module supports get details of an existing replication session. Updating the state of the replication session.
 
 ### Parameters
-                                                                                                                                                                                                                                                        
+                                                                                                                                                                                                                                                                                                
 <table>
     <tr>
         <th colspan=1>Parameter</th>
@@ -9414,13 +9914,45 @@ Replication session operations on a PowerStore storage system
         <th>Choices</th>
         <th width="80%">Description</th>
     </tr>
+                                                            <tr>
+            <td colspan=1 > filesystem</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Name/ID of the filesystem for which replication session exists.  <br> Parameter filesystem, nas_server, volume_group, volume, and session_id are mutually exclusive. </td>
+        </tr>
                     <tr>
-            <td colspan=1 > timeout</td>
-            <td> int  </td>
+            <td colspan=1 > nas_server</td>
+            <td> str  </td>
             <td></td>
-            <td> 120 </td>
             <td></td>
-            <td> <br> Time after which the connection will get terminated.  <br> It is to be mentioned in seconds. </td>
+            <td></td>
+            <td> <br> Name/ID of the NAS server for which replication session exists.  <br> Parameter filesystem, nas_server, volume_group, volume, and session_id are mutually exclusive. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > volume_group</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Name/ID of the volume group for which a replication session exists.  <br> Parameter filesystem, nas_server, volume_group, volume, and session_id are mutually exclusive. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > volume</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Name/ID of the volume for which replication session exists.  <br> Parameter filesystem, nas_server, volume_group, volume, and session_id are mutually exclusive. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > session_id</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> ID of the replication session.  <br> Parameter filesystem, nas_server, volume_group, volume, and session_id are mutually exclusive. </td>
         </tr>
                     <tr>
             <td colspan=1 > session_state</td>
@@ -9431,28 +9963,12 @@ Replication session operations on a PowerStore storage system
             <td> <br> State in which the replication session is present after performing the task. </td>
         </tr>
                     <tr>
-            <td colspan=1 > volume</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Name/ID of the volume for which replication session exists.  <br> Parameter volume_group, volume, and session_id are mutually exclusive. </td>
-        </tr>
-                    <tr>
             <td colspan=1 > array_ip</td>
             <td> str  </td>
             <td> True </td>
             <td></td>
             <td></td>
             <td> <br> IP or FQDN of the PowerStore management system. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > session_id</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> ID of the replication session.  <br> Parameter volume_group, volume, and session_id are mutually exclusive. </td>
         </tr>
                     <tr>
             <td colspan=1 > verifycert</td>
@@ -9463,12 +9979,12 @@ Replication session operations on a PowerStore storage system
             <td> <br> Boolean variable to specify whether to validate SSL certificate or not.  <br> True - indicates that the SSL certificate should be verified. Set the environment variable REQUESTS_CA_BUNDLE to the path of the SSL certificate.  <br> False - indicates that the SSL certificate should not be verified. </td>
         </tr>
                     <tr>
-            <td colspan=1 > port</td>
-            <td> int  </td>
+            <td colspan=1 > user</td>
+            <td> str  </td>
+            <td> True </td>
             <td></td>
             <td></td>
-            <td></td>
-            <td> <br> Port number for the PowerStore array.  <br> If not passed, it will take 443 as default. </td>
+            <td> <br> The username of the PowerStore host. </td>
         </tr>
                     <tr>
             <td colspan=1 > password</td>
@@ -9479,28 +9995,29 @@ Replication session operations on a PowerStore storage system
             <td> <br> The password of the PowerStore host. </td>
         </tr>
                     <tr>
-            <td colspan=1 > volume_group</td>
-            <td> str  </td>
+            <td colspan=1 > timeout</td>
+            <td> int  </td>
             <td></td>
+            <td> 120 </td>
             <td></td>
-            <td></td>
-            <td> <br> Name/ID of the volume group for which a replication session exists.  <br> Parameter volume_group, volume, and session_id are mutually exclusive. </td>
+            <td> <br> Time after which the connection will get terminated.  <br> It is to be mentioned in seconds. </td>
         </tr>
                     <tr>
-            <td colspan=1 > user</td>
-            <td> str  </td>
-            <td> True </td>
+            <td colspan=1 > port</td>
+            <td> int  </td>
             <td></td>
             <td></td>
-            <td> <br> The username of the PowerStore host. </td>
+            <td></td>
+            <td> <br> Port number for the PowerStore array.  <br> If not passed, it will take 443 as default. </td>
         </tr>
-                                                                                            </table>
+                                                    </table>
 
 ### Notes
 * Manual synchronization for a replication session is not supported through the Ansible module.
 * When the current state of the replication session is 'OK' and in the playbook task 'synchronizing', then it will return "changed" as False.
 * The changed as False in above scenario is because of there is a scheduled synchronization in place with the associated replication rule's RPO in the protection policy.
 * The check_mode is not supported.
+* nas_server and filesystem parameters are supported only for PowerStore version 3.0.0. and above.
 * The modules present in this collection named as 'dellemc.powerstore' are built to support the Dell PowerStore storage platform.
 
 ### Examples
@@ -9550,7 +10067,7 @@ Replication session operations on a PowerStore storage system
         <th>Returned</th>
         <th width="100%">Description</th>
     </tr>
-                                    <tr>
+                                                                                            <tr>
             <td colspan=2 > changed </td>
             <td>  bool </td>
             <td> always </td>
@@ -9564,52 +10081,10 @@ Replication session operations on a PowerStore storage system
         </tr>
                             <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > local_resource_id </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Unique identifier of the local storage resource for the replication session. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > role </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Role of the replication session. Source - The local resource is the source of the remote replication session. Destination - The local resource is the destination of the remote replication session. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > progress_percentage </td>
-                <td> int </td>
-                <td>success</td>
-                <td> Progress of the current replication operation. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > replication_rule_id </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Associated replication rule instance if created by policy engine. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=1 > estimated_completion_timestamp </td>
                 <td> str </td>
                 <td>success</td>
                 <td> Estimated completion time of the current replication operation. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > last_sync_timestamp </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Time of last successful synchronization. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > name </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Name of the replication rule. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
@@ -9620,17 +10095,31 @@ Replication session operations on a PowerStore storage system
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > remote_system_id </td>
+                <td colspan=1 > last_sync_timestamp </td>
                 <td> str </td>
                 <td>success</td>
-                <td> Unique identifier of the remote system instance. </td>
+                <td> Time of last successful synchronization. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > state </td>
+                <td colspan=1 > local_resource_id </td>
                 <td> str </td>
                 <td>success</td>
-                <td> State of the replication session. </td>
+                <td> Unique identifier of the local storage resource for the replication session. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > name </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Name of the replication rule. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > progress_percentage </td>
+                <td> int </td>
+                <td>success</td>
+                <td> Progress of the current replication operation. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
@@ -9641,12 +10130,40 @@ Replication session operations on a PowerStore storage system
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > remote_system_id </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Unique identifier of the remote system instance. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > replication_rule_id </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Associated replication rule instance if created by policy engine. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=1 > resource_type </td>
                 <td> str </td>
                 <td>success</td>
                 <td> Storage resource type eligible for replication protection. volume - Replication session created on a volume. volume_group - Replication session created on a volume group. </td>
             </tr>
-                                                                                                </table>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > role </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Role of the replication session. Source - The local resource is the source of the remote replication session. Destination - The local resource is the destination of the remote replication session. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > state </td>
+                <td> str </td>
+                <td>success</td>
+                <td> State of the replication session. </td>
+            </tr>
+                                        </table>
 
 ### Authors
 * P Srinivas Rao (@srinivas-rao5) <ansible.team@dell.com>
@@ -9670,21 +10187,13 @@ Get details of the roles present on the PowerStore storage system
         <th>Choices</th>
         <th width="80%">Description</th>
     </tr>
-                    <tr>
-            <td colspan=1 > timeout</td>
-            <td> int  </td>
-            <td></td>
-            <td> 120 </td>
-            <td></td>
-            <td> <br> Time after which the connection will get terminated.  <br> It is to be mentioned in seconds. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > array_ip</td>
+                                                            <tr>
+            <td colspan=1 > role_name</td>
             <td> str  </td>
-            <td> True </td>
             <td></td>
             <td></td>
-            <td> <br> IP or FQDN of the PowerStore management system. </td>
+            <td></td>
+            <td> <br> Name of the role. </td>
         </tr>
                     <tr>
             <td colspan=1 > role_id</td>
@@ -9695,28 +10204,20 @@ Get details of the roles present on the PowerStore storage system
             <td> <br> Id of the role. </td>
         </tr>
                     <tr>
-            <td colspan=1 > user</td>
-            <td> str  </td>
-            <td> True </td>
-            <td></td>
-            <td></td>
-            <td> <br> The username of the PowerStore host. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > role_name</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Name of the role. </td>
-        </tr>
-                    <tr>
             <td colspan=1 > state</td>
             <td> str  </td>
             <td> True </td>
             <td></td>
             <td> <ul> <li>absent</li>  <li>present</li> </ul></td>
             <td> <br> Define whether the role should exist or not.  <br> Value present, indicates that the role should exist on the system.  <br> Value absent, indicates that the role should not exist on the system. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > array_ip</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td></td>
+            <td> <br> IP or FQDN of the PowerStore management system. </td>
         </tr>
                     <tr>
             <td colspan=1 > verifycert</td>
@@ -9727,12 +10228,12 @@ Get details of the roles present on the PowerStore storage system
             <td> <br> Boolean variable to specify whether to validate SSL certificate or not.  <br> True - indicates that the SSL certificate should be verified. Set the environment variable REQUESTS_CA_BUNDLE to the path of the SSL certificate.  <br> False - indicates that the SSL certificate should not be verified. </td>
         </tr>
                     <tr>
-            <td colspan=1 > port</td>
-            <td> int  </td>
+            <td colspan=1 > user</td>
+            <td> str  </td>
+            <td> True </td>
             <td></td>
             <td></td>
-            <td></td>
-            <td> <br> Port number for the PowerStore array.  <br> If not passed, it will take 443 as default. </td>
+            <td> <br> The username of the PowerStore host. </td>
         </tr>
                     <tr>
             <td colspan=1 > password</td>
@@ -9742,7 +10243,23 @@ Get details of the roles present on the PowerStore storage system
             <td></td>
             <td> <br> The password of the PowerStore host. </td>
         </tr>
-                                                                                            </table>
+                    <tr>
+            <td colspan=1 > timeout</td>
+            <td> int  </td>
+            <td></td>
+            <td> 120 </td>
+            <td></td>
+            <td> <br> Time after which the connection will get terminated.  <br> It is to be mentioned in seconds. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > port</td>
+            <td> int  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Port number for the PowerStore array.  <br> If not passed, it will take 443 as default. </td>
+        </tr>
+                                                    </table>
 
 ### Notes
 * Only getting the details of the role is supported by the ansible module.
@@ -9780,7 +10297,13 @@ Get details of the roles present on the PowerStore storage system
         <th>Returned</th>
         <th width="100%">Description</th>
     </tr>
-                                    <tr>
+                                                                                            <tr>
+            <td colspan=2 > changed </td>
+            <td>  bool </td>
+            <td> always </td>
+            <td> Whether or not the resource has changed. </td>
+        </tr>
+                    <tr>
             <td colspan=2 > role_details </td>
             <td>  complex </td>
             <td> When role exists. </td>
@@ -9788,17 +10311,10 @@ Get details of the roles present on the PowerStore storage system
         </tr>
                             <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > name </td>
+                <td colspan=1 > description </td>
                 <td> str </td>
                 <td>success</td>
-                <td> The name of the role. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > is_built_in </td>
-                <td> bool </td>
-                <td>success</td>
-                <td> Indicates whether the role is built-in. </td>
+                <td> Description of the role. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
@@ -9809,18 +10325,19 @@ Get details of the roles present on the PowerStore storage system
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > description </td>
+                <td colspan=1 > is_built_in </td>
+                <td> bool </td>
+                <td>success</td>
+                <td> Indicates whether the role is built-in. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > name </td>
                 <td> str </td>
                 <td>success</td>
-                <td> Description of the role. </td>
+                <td> The name of the role. </td>
             </tr>
-                                        <tr>
-            <td colspan=2 > changed </td>
-            <td>  bool </td>
-            <td> always </td>
-            <td> Whether or not the resource has changed. </td>
-        </tr>
-                                                                            </table>
+                                        </table>
 
 ### Authors
 * P Srinivas Rao (@srinivas-rao5) <ansible.team@dell.com>
@@ -9844,29 +10361,21 @@ Security configuration operations for PowerStore Storage System
         <th>Choices</th>
         <th width="80%">Description</th>
     </tr>
-                    <tr>
-            <td colspan=1 > timeout</td>
+                                                            <tr>
+            <td colspan=1 > security_config_id</td>
             <td> int  </td>
-            <td></td>
-            <td> 120 </td>
-            <td></td>
-            <td> <br> Time after which the connection will get terminated.  <br> It is to be mentioned in seconds. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > verifycert</td>
-            <td> bool  </td>
             <td> True </td>
             <td></td>
-            <td> <ul> <li>True</li>  <li>False</li> </ul></td>
-            <td> <br> Boolean variable to specify whether to validate SSL certificate or not.  <br> True - indicates that the SSL certificate should be verified. Set the environment variable REQUESTS_CA_BUNDLE to the path of the SSL certificate.  <br> False - indicates that the SSL certificate should not be verified. </td>
+            <td></td>
+            <td> <br> ID of the security configuration.  <br> Mandatory for all operations. </td>
         </tr>
                     <tr>
-            <td colspan=1 > user</td>
+            <td colspan=1 > protocol_mode</td>
             <td> str  </td>
-            <td> True </td>
             <td></td>
             <td></td>
-            <td> <br> The username of the PowerStore host. </td>
+            <td> <ul> <li>TLSv1_0</li>  <li>TLSv1_1</li>  <li>TLSv1_2</li> </ul></td>
+            <td> <br> Protocol mode of the security configuration.  <br> Mandatory only for modify operation. </td>
         </tr>
                     <tr>
             <td colspan=1 > state</td>
@@ -9885,20 +10394,20 @@ Security configuration operations for PowerStore Storage System
             <td> <br> IP or FQDN of the PowerStore management system. </td>
         </tr>
                     <tr>
-            <td colspan=1 > protocol_mode</td>
-            <td> str  </td>
+            <td colspan=1 > verifycert</td>
+            <td> bool  </td>
+            <td> True </td>
             <td></td>
-            <td></td>
-            <td> <ul> <li>TLSv1_0</li>  <li>TLSv1_1</li>  <li>TLSv1_2</li> </ul></td>
-            <td> <br> Protocol mode of the security configuration.  <br> Mandatory only for modify operation. </td>
+            <td> <ul> <li>True</li>  <li>False</li> </ul></td>
+            <td> <br> Boolean variable to specify whether to validate SSL certificate or not.  <br> True - indicates that the SSL certificate should be verified. Set the environment variable REQUESTS_CA_BUNDLE to the path of the SSL certificate.  <br> False - indicates that the SSL certificate should not be verified. </td>
         </tr>
                     <tr>
-            <td colspan=1 > port</td>
-            <td> int  </td>
+            <td colspan=1 > user</td>
+            <td> str  </td>
+            <td> True </td>
             <td></td>
             <td></td>
-            <td></td>
-            <td> <br> Port number for the PowerStore array.  <br> If not passed, it will take 443 as default. </td>
+            <td> <br> The username of the PowerStore host. </td>
         </tr>
                     <tr>
             <td colspan=1 > password</td>
@@ -9909,14 +10418,22 @@ Security configuration operations for PowerStore Storage System
             <td> <br> The password of the PowerStore host. </td>
         </tr>
                     <tr>
-            <td colspan=1 > security_config_id</td>
+            <td colspan=1 > timeout</td>
             <td> int  </td>
-            <td> True </td>
             <td></td>
+            <td> 120 </td>
             <td></td>
-            <td> <br> ID of the security configuration.  <br> Mandatory for all operations. </td>
+            <td> <br> Time after which the connection will get terminated.  <br> It is to be mentioned in seconds. </td>
         </tr>
-                                                                                            </table>
+                    <tr>
+            <td colspan=1 > port</td>
+            <td> int  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Port number for the PowerStore array.  <br> If not passed, it will take 443 as default. </td>
+        </tr>
+                                                    </table>
 
 ### Notes
 * Creation and deletion of security configs is not supported by Ansible modules.
@@ -9955,7 +10472,7 @@ Security configuration operations for PowerStore Storage System
         <th>Returned</th>
         <th width="100%">Description</th>
     </tr>
-                                    <tr>
+                                                                                            <tr>
             <td colspan=2 > changed </td>
             <td>  bool </td>
             <td> always </td>
@@ -9969,13 +10486,6 @@ Security configuration operations for PowerStore Storage System
         </tr>
                             <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > protocol_mode </td>
-                <td> str </td>
-                <td>success</td>
-                <td> The protocol mode of the security configuration. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=1 > id </td>
                 <td> str </td>
                 <td>success</td>
@@ -9988,7 +10498,14 @@ Security configuration operations for PowerStore Storage System
                 <td>success</td>
                 <td> Idle time (in seconds) after which login sessions will expire and require re-authentication. </td>
             </tr>
-                                                                                                </table>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > protocol_mode </td>
+                <td> str </td>
+                <td>success</td>
+                <td> The protocol mode of the security configuration. </td>
+            </tr>
+                                        </table>
 
 ### Authors
 * Bhavneet Sharma (@sharmb5) <ansible.team@dell.com>
@@ -10012,85 +10529,13 @@ Manage SMB shares on a PowerStore storage system
         <th>Choices</th>
         <th width="80%">Description</th>
     </tr>
-                    <tr>
-            <td colspan=1 > umask</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> The default UNIX umask for new files created on the SMB Share.  <br> During creation, if not mentioned, then the default is "022".  <br> For all other operations, the default is None. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > offline_availability</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td> <ul> <li>MANUAL</li>  <li>DOCUMENTS</li>  <li>PROGRAMS</li>  <li>NONE</li> </ul></td>
-            <td> <br> Defines valid states of Offline Availability.  <br> MANUAL- Only specified files will be available offline.  <br> DOCUMENTS- All files that users open will be available offline.  <br> PROGRAMS- Program will preferably run from the offline cache even when connected to the network. All files that users open will be available offline.  <br> NONE- Prevents clients from storing documents and programs in offline cache. </td>
-        </tr>
-                    <tr>
+                                                            <tr>
             <td colspan=1 > share_name</td>
             <td> str  </td>
             <td></td>
             <td></td>
             <td></td>
             <td> <br> Name of the SMB share.  <br> Required during creation of the SMB share.  <br> For all other operations either share_name or share_id is required. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > filesystem</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> The ID/Name of the File System.  <br> Either filesystem or snapshot is required for creation of the SMB share.  <br> If filesystem name is specified, then nas_server is required to uniquely identify the filesystem.  <br> If filesystem parameter is provided, then snapshot cannot be specified. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > array_ip</td>
-            <td> str  </td>
-            <td> True </td>
-            <td></td>
-            <td></td>
-            <td> <br> IP or FQDN of the PowerStore management system. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > is_continuous_availability_enabled</td>
-            <td> bool  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Indicates whether continuous availability for SMB 3.0 is enabled.  <br> During creation, if not mentioned, then the default is False. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > port</td>
-            <td> int  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Port number for the PowerStore array.  <br> If not passed, it will take 443 as default. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > is_branch_cache_enabled</td>
-            <td> bool  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Indicates whether Branch Cache optimization for SMB share is enabled.  <br> During creation, if not mentioned then default is False. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > path</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Local path to the file system/Snapshot or any existing sub-folder of the file system/Snapshot that is shared over the network.  <br> Path is relative to the base of the NAS server and must start with the name of the filesystem.  <br> Required for creation of the SMB share. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > timeout</td>
-            <td> int  </td>
-            <td></td>
-            <td> 120 </td>
-            <td></td>
-            <td> <br> Time after which the connection will get terminated.  <br> It is to be mentioned in seconds. </td>
         </tr>
                     <tr>
             <td colspan=1 > share_id</td>
@@ -10101,60 +10546,36 @@ Manage SMB shares on a PowerStore storage system
             <td> <br> ID of the SMB share.  <br> Should not be specified during creation. ID is auto generated.  <br> For all other operations either share_name or share_id is required.  <br> If share_id is used then no need to pass nas_server/filesystem/snapshot/ path. </td>
         </tr>
                     <tr>
+            <td colspan=1 > path</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Local path to the file system/Snapshot or any existing sub-folder of the file system/Snapshot that is shared over the network.  <br> Path is relative to the base of the NAS server and must start with the name of the filesystem.  <br> Required for creation of the SMB share. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > filesystem</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> The ID/Name of the File System.  <br> Either filesystem or snapshot is required for creation of the SMB share.  <br> If filesystem name is specified, then nas_server is required to uniquely identify the filesystem.  <br> If filesystem parameter is provided, then snapshot cannot be specified. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > snapshot</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> The ID/Name of the Snapshot.  <br> Either filesystem or snapshot is required for creation of the SMB share.  <br> If snapshot name is specified, then nas_server is required to uniquely identify the snapshot.  <br> If snapshot parameter is provided, then filesystem cannot be specified.  <br> SMB share can be created only if access type of snapshot is "protocol". </td>
+        </tr>
+                    <tr>
             <td colspan=1 > nas_server</td>
             <td> str  </td>
             <td></td>
             <td></td>
             <td></td>
             <td> <br> The ID/Name of the NAS Server.  <br> It is not required if share_id is used. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > user</td>
-            <td> str  </td>
-            <td> True </td>
-            <td></td>
-            <td></td>
-            <td> <br> The username of the PowerStore host. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > state</td>
-            <td> str  </td>
-            <td> True </td>
-            <td></td>
-            <td> <ul> <li>absent</li>  <li>present</li> </ul></td>
-            <td> <br> Define whether the SMB share should exist or not.  <br> Value present indicates that the share should exist on the system.  <br> Value absent indicates that the share should not exist on the system. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > is_abe_enabled</td>
-            <td> bool  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Indicates whether Access-based Enumeration (ABE) for SMB share is enabled.  <br> During creation, if not mentioned, then the default is False. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > is_encryption_enabled</td>
-            <td> bool  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Indicates whether encryption for SMB 3.0 is enabled at the shared folder level.  <br> During creation, if not mentioned then default is False. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > verifycert</td>
-            <td> bool  </td>
-            <td> True </td>
-            <td></td>
-            <td> <ul> <li>True</li>  <li>False</li> </ul></td>
-            <td> <br> Boolean variable to specify whether to validate SSL certificate or not.  <br> True - indicates that the SSL certificate should be verified. Set the environment variable REQUESTS_CA_BUNDLE to the path of the SSL certificate.  <br> False - indicates that the SSL certificate should not be verified. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > password</td>
-            <td> str  </td>
-            <td> True </td>
-            <td></td>
-            <td></td>
-            <td> <br> The password of the PowerStore host. </td>
         </tr>
                     <tr>
             <td colspan=1 > description</td>
@@ -10165,14 +10586,110 @@ Manage SMB shares on a PowerStore storage system
             <td> <br> Description for the SMB share.  <br> Optional parameter when creating a share.  <br> To modify, pass the new value in description field. </td>
         </tr>
                     <tr>
-            <td colspan=1 > snapshot</td>
+            <td colspan=1 > is_abe_enabled</td>
+            <td> bool  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Indicates whether Access-based Enumeration (ABE) for SMB share is enabled.  <br> During creation, if not mentioned, then the default is False. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > is_branch_cache_enabled</td>
+            <td> bool  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Indicates whether Branch Cache optimization for SMB share is enabled.  <br> During creation, if not mentioned then default is False. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > is_continuous_availability_enabled</td>
+            <td> bool  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Indicates whether continuous availability for SMB 3.0 is enabled.  <br> During creation, if not mentioned, then the default is False. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > is_encryption_enabled</td>
+            <td> bool  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Indicates whether encryption for SMB 3.0 is enabled at the shared folder level.  <br> During creation, if not mentioned then default is False. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > offline_availability</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td> <ul> <li>MANUAL</li>  <li>DOCUMENTS</li>  <li>PROGRAMS</li>  <li>NONE</li> </ul></td>
+            <td> <br> Defines valid states of Offline Availability.  <br> MANUAL- Only specified files will be available offline.  <br> DOCUMENTS- All files that users open will be available offline.  <br> PROGRAMS- Program will preferably run from the offline cache even when connected to the network. All files that users open will be available offline.  <br> NONE- Prevents clients from storing documents and programs in offline cache. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > umask</td>
             <td> str  </td>
             <td></td>
             <td></td>
             <td></td>
-            <td> <br> The ID/Name of the Snapshot.  <br> Either filesystem or snapshot is required for creation of the SMB share.  <br> If snapshot name is specified, then nas_server is required to uniquely identify the snapshot.  <br> If snapshot parameter is provided, then filesystem cannot be specified.  <br> SMB share can be created only if access type of snapshot is "protocol". </td>
+            <td> <br> The default UNIX umask for new files created on the SMB Share.  <br> During creation, if not mentioned, then the default is "022".  <br> For all other operations, the default is None. </td>
         </tr>
-                                                                                            </table>
+                    <tr>
+            <td colspan=1 > state</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td> <ul> <li>absent</li>  <li>present</li> </ul></td>
+            <td> <br> Define whether the SMB share should exist or not.  <br> Value present indicates that the share should exist on the system.  <br> Value absent indicates that the share should not exist on the system. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > array_ip</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td></td>
+            <td> <br> IP or FQDN of the PowerStore management system. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > verifycert</td>
+            <td> bool  </td>
+            <td> True </td>
+            <td></td>
+            <td> <ul> <li>True</li>  <li>False</li> </ul></td>
+            <td> <br> Boolean variable to specify whether to validate SSL certificate or not.  <br> True - indicates that the SSL certificate should be verified. Set the environment variable REQUESTS_CA_BUNDLE to the path of the SSL certificate.  <br> False - indicates that the SSL certificate should not be verified. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > user</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td></td>
+            <td> <br> The username of the PowerStore host. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > password</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td></td>
+            <td> <br> The password of the PowerStore host. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > timeout</td>
+            <td> int  </td>
+            <td></td>
+            <td> 120 </td>
+            <td></td>
+            <td> <br> Time after which the connection will get terminated.  <br> It is to be mentioned in seconds. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > port</td>
+            <td> int  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Port number for the PowerStore array.  <br> If not passed, it will take 443 as default. </td>
+        </tr>
+                                                    </table>
 
 ### Notes
 * When the ID of the filesystem/snapshot is passed then nas_server is not required. If passed, then the filesystem/snapshot should exist for the nas_server, else the task will fail.
@@ -10277,7 +10794,7 @@ Manage SMB shares on a PowerStore storage system
         <th>Returned</th>
         <th width="100%">Description</th>
     </tr>
-                                    <tr>
+                                                                                            <tr>
             <td colspan=3 > changed </td>
             <td>  bool </td>
             <td> always </td>
@@ -10291,17 +10808,70 @@ Manage SMB shares on a PowerStore storage system
         </tr>
                             <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > name </td>
+                <td colspan=2 > description </td>
                 <td> str </td>
                 <td>success</td>
-                <td> Name of the SMB share. </td>
+                <td> Additional information about the share. </td>
             </tr>
                                 <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > file_system </td>
+                <td> complex </td>
+                <td>success</td>
+                <td> Includes ID and Name of filesystem and nas server for which smb share exists. </td>
+            </tr>
+                                         <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=1 > filesystem_type </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> Type of filesystem. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=1 > id </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> ID of filesystem. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=1 > name </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> Name of filesystem. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=1 > nas_server </td>
+                    <td> dict </td>
+                    <td>success</td>
+                    <td> nas_server of filesystem. </td>
+                </tr>
+                                                            <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=2 > id </td>
                 <td> str </td>
                 <td>success</td>
                 <td> The ID of the SMB share. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > is_ABE_enabled </td>
+                <td> bool </td>
+                <td>success</td>
+                <td> Whether Access Based enumeration is enforced or not </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > is_branch_cache_enabled </td>
+                <td> bool </td>
+                <td>success</td>
+                <td> Whether branch cache is enabled or not. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
@@ -10319,65 +10889,12 @@ Manage SMB shares on a PowerStore storage system
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > is_branch_cache_enabled </td>
-                <td> bool </td>
-                <td>success</td>
-                <td> Whether branch cache is enabled or not. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > file_system </td>
-                <td> complex </td>
-                <td>success</td>
-                <td> Includes ID and Name of filesystem and nas server for which smb share exists. </td>
-            </tr>
-                                         <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=1 > name </td>
-                    <td> str </td>
-                    <td>success</td>
-                    <td> Name of filesystem. </td>
-                </tr>
-                                             <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=1 > filesystem_type </td>
-                    <td> str </td>
-                    <td>success</td>
-                    <td> Type of filesystem. </td>
-                </tr>
-                                             <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=1 > nas_server </td>
-                    <td> dict </td>
-                    <td>success</td>
-                    <td> nas_server of filesystem. </td>
-                </tr>
-                                             <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=1 > id </td>
-                    <td> str </td>
-                    <td>success</td>
-                    <td> ID of filesystem. </td>
-                </tr>
-                                                            <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > description </td>
+                <td colspan=2 > name </td>
                 <td> str </td>
                 <td>success</td>
-                <td> Additional information about the share. </td>
+                <td> Name of the SMB share. </td>
             </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > is_ABE_enabled </td>
-                <td> bool </td>
-                <td>success</td>
-                <td> Whether Access Based enumeration is enforced or not </td>
-            </tr>
-                                                                                                </table>
+                                        </table>
 
 ### Authors
 * P Srinivas Rao (@srinivas-rao5) <ansible.team@dell.com>
@@ -10402,61 +10919,13 @@ SMTP configuration operations on a PowerStore storage system
         <th>Choices</th>
         <th width="80%">Description</th>
     </tr>
-                    <tr>
-            <td colspan=1 > source_email</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Source email address used for sending SMTP messages. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > array_ip</td>
-            <td> str  </td>
-            <td> True </td>
-            <td></td>
-            <td></td>
-            <td> <br> IP or FQDN of the PowerStore management system. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > port</td>
-            <td> int  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Port number for the PowerStore array.  <br> If not passed, it will take 443 as default. </td>
-        </tr>
-                    <tr>
+                                                            <tr>
             <td colspan=1 > smtp_id</td>
             <td> int  </td>
             <td> True </td>
             <td></td>
             <td></td>
             <td> <br> Unique identifier of the SMTP configuration. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > timeout</td>
-            <td> int  </td>
-            <td></td>
-            <td> 120 </td>
-            <td></td>
-            <td> <br> Time after which the connection will get terminated.  <br> It is to be mentioned in seconds. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > smtp_port</td>
-            <td> int  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Port used for sending SMTP messages. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > user</td>
-            <td> str  </td>
-            <td> True </td>
-            <td></td>
-            <td></td>
-            <td> <br> The username of the PowerStore host. </td>
         </tr>
                     <tr>
             <td colspan=1 > smtp_address</td>
@@ -10467,12 +10936,44 @@ SMTP configuration operations on a PowerStore storage system
             <td> <br> IP address of the SMTP server. </td>
         </tr>
                     <tr>
+            <td colspan=1 > smtp_port</td>
+            <td> int  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Port used for sending SMTP messages. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > source_email</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Source email address used for sending SMTP messages. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > destination_email</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Destination email address for the test. </td>
+        </tr>
+                    <tr>
             <td colspan=1 > state</td>
             <td> str  </td>
             <td> True </td>
             <td></td>
             <td> <ul> <li>present</li>  <li>absent</li> </ul></td>
             <td> <br> The state of the SMTP configuration after the task is performed.  <br> For Delete operation only, it should be set to "absent".  <br> For all operations it should be set to "present". </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > array_ip</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td></td>
+            <td> <br> IP or FQDN of the PowerStore management system. </td>
         </tr>
                     <tr>
             <td colspan=1 > verifycert</td>
@@ -10483,6 +10984,14 @@ SMTP configuration operations on a PowerStore storage system
             <td> <br> Boolean variable to specify whether to validate SSL certificate or not.  <br> True - indicates that the SSL certificate should be verified. Set the environment variable REQUESTS_CA_BUNDLE to the path of the SSL certificate.  <br> False - indicates that the SSL certificate should not be verified. </td>
         </tr>
                     <tr>
+            <td colspan=1 > user</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td></td>
+            <td> <br> The username of the PowerStore host. </td>
+        </tr>
+                    <tr>
             <td colspan=1 > password</td>
             <td> str  </td>
             <td> True </td>
@@ -10491,14 +11000,22 @@ SMTP configuration operations on a PowerStore storage system
             <td> <br> The password of the PowerStore host. </td>
         </tr>
                     <tr>
-            <td colspan=1 > destination_email</td>
-            <td> str  </td>
+            <td colspan=1 > timeout</td>
+            <td> int  </td>
             <td></td>
+            <td> 120 </td>
             <td></td>
-            <td></td>
-            <td> <br> Destination email address for the test. </td>
+            <td> <br> Time after which the connection will get terminated.  <br> It is to be mentioned in seconds. </td>
         </tr>
-                                                                                            </table>
+                    <tr>
+            <td colspan=1 > port</td>
+            <td> int  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Port number for the PowerStore array.  <br> If not passed, it will take 443 as default. </td>
+        </tr>
+                                                    </table>
 
 ### Notes
 * Idempotency is not supported for test operation for smtp_config module.
@@ -10548,7 +11065,7 @@ SMTP configuration operations on a PowerStore storage system
         <th>Returned</th>
         <th width="100%">Description</th>
     </tr>
-                                    <tr>
+                                                                                            <tr>
             <td colspan=2 > changed </td>
             <td>  bool </td>
             <td> always </td>
@@ -10562,6 +11079,20 @@ SMTP configuration operations on a PowerStore storage system
         </tr>
                             <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > address </td>
+                <td> str </td>
+                <td>success</td>
+                <td> IP address of the SMTP server. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > id </td>
+                <td> int </td>
+                <td>success</td>
+                <td> Unique identifier of SMTP configuration. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=1 > port </td>
                 <td> int </td>
                 <td>success</td>
@@ -10574,21 +11105,7 @@ SMTP configuration operations on a PowerStore storage system
                 <td>success</td>
                 <td> Source email address used for sending SMTP messages. </td>
             </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > id </td>
-                <td> int </td>
-                <td>success</td>
-                <td> Unique identifier of SMTP configuration. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=1 > address </td>
-                <td> str </td>
-                <td>success</td>
-                <td> IP address of the SMTP server. </td>
-            </tr>
-                                                                                                </table>
+                                        </table>
 
 ### Authors
 * Trisha Datta (@Trisha_Datta) <ansible.team@dell.com>
@@ -10613,13 +11130,37 @@ Manage Snapshots for PowerStore
         <th>Choices</th>
         <th width="80%">Description</th>
     </tr>
-                    <tr>
+                                                            <tr>
             <td colspan=1 > snapshot_name</td>
             <td> str  </td>
             <td></td>
             <td></td>
             <td></td>
             <td> <br> The name of the Snapshot. Either snapshot name or ID is required. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > snapshot_id</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> The ID of the Snapshot. Either snapshot ID or Snapshot name is required. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > volume</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> The volume. This could be the volume name or ID. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > volume_group</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> The volume group. This could be the volume group name or ID. </td>
         </tr>
                     <tr>
             <td colspan=1 > new_snapshot_name</td>
@@ -10638,52 +11179,12 @@ Manage Snapshots for PowerStore
             <td> <br> The retention value for the Snapshot.  <br> If the retention value is not specified, the Snapshot details would be returned.  <br> To create a Snapshot, either a retention or expiration timestamp must be given.  <br> If the Snapshot does not have any retention value - specify it as 'None'. </td>
         </tr>
                     <tr>
-            <td colspan=1 > port</td>
-            <td> int  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Port number for the PowerStore array.  <br> If not passed, it will take 443 as default. </td>
-        </tr>
-                    <tr>
             <td colspan=1 > retention_unit</td>
             <td> str  </td>
             <td></td>
             <td></td>
             <td> <ul> <li>hours</li>  <li>days</li> </ul></td>
             <td> <br> The unit for retention.  <br> If this unit is not specified, 'hours' is taken as default retention_unit.  <br> If desired_retention is specified, expiration_timestamp cannot be specified. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > snapshot_id</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> The ID of the Snapshot. Either snapshot ID or Snapshot name is required. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > description</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> The description for the Snapshot. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > timeout</td>
-            <td> int  </td>
-            <td></td>
-            <td> 120 </td>
-            <td></td>
-            <td> <br> Time after which the connection will get terminated.  <br> It is to be mentioned in seconds. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > array_ip</td>
-            <td> str  </td>
-            <td> True </td>
-            <td></td>
-            <td></td>
-            <td> <br> IP or FQDN of the PowerStore management system. </td>
         </tr>
                     <tr>
             <td colspan=1 > expiration_timestamp</td>
@@ -10694,12 +11195,12 @@ Manage Snapshots for PowerStore
             <td> <br> The expiration timestamp of the Snapshot. This should be provided in UTC format, e.g 2019-07-24T10:54:54Z. </td>
         </tr>
                     <tr>
-            <td colspan=1 > user</td>
+            <td colspan=1 > description</td>
             <td> str  </td>
-            <td> True </td>
             <td></td>
             <td></td>
-            <td> <br> The username of the PowerStore host. </td>
+            <td></td>
+            <td> <br> The description for the Snapshot. </td>
         </tr>
                     <tr>
             <td colspan=1 > state</td>
@@ -10710,6 +11211,14 @@ Manage Snapshots for PowerStore
             <td> <br> Defines whether the Snapshot should exist or not. </td>
         </tr>
                     <tr>
+            <td colspan=1 > array_ip</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td></td>
+            <td> <br> IP or FQDN of the PowerStore management system. </td>
+        </tr>
+                    <tr>
             <td colspan=1 > verifycert</td>
             <td> bool  </td>
             <td> True </td>
@@ -10718,12 +11227,12 @@ Manage Snapshots for PowerStore
             <td> <br> Boolean variable to specify whether to validate SSL certificate or not.  <br> True - indicates that the SSL certificate should be verified. Set the environment variable REQUESTS_CA_BUNDLE to the path of the SSL certificate.  <br> False - indicates that the SSL certificate should not be verified. </td>
         </tr>
                     <tr>
-            <td colspan=1 > volume</td>
+            <td colspan=1 > user</td>
             <td> str  </td>
+            <td> True </td>
             <td></td>
             <td></td>
-            <td></td>
-            <td> <br> The volume. This could be the volume name or ID. </td>
+            <td> <br> The username of the PowerStore host. </td>
         </tr>
                     <tr>
             <td colspan=1 > password</td>
@@ -10734,14 +11243,22 @@ Manage Snapshots for PowerStore
             <td> <br> The password of the PowerStore host. </td>
         </tr>
                     <tr>
-            <td colspan=1 > volume_group</td>
-            <td> str  </td>
+            <td colspan=1 > timeout</td>
+            <td> int  </td>
             <td></td>
+            <td> 120 </td>
             <td></td>
-            <td></td>
-            <td> <br> The volume group. This could be the volume group name or ID. </td>
+            <td> <br> Time after which the connection will get terminated.  <br> It is to be mentioned in seconds. </td>
         </tr>
-                                                                                            </table>
+                    <tr>
+            <td colspan=1 > port</td>
+            <td> int  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Port number for the PowerStore array.  <br> If not passed, it will take 443 as default. </td>
+        </tr>
+                                                    </table>
 
 ### Notes
 * The check_mode is not supported.
@@ -10850,124 +11367,156 @@ Manage Snapshots for PowerStore
 ```
 
 ### Return Values
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    
 <table>
     <tr>
-        <th colspan=3>Key</th>
+        <th colspan=4>Key</th>
         <th>Type</th>
         <th>Returned</th>
         <th width="100%">Description</th>
     </tr>
-                                    <tr>
-            <td colspan=3 > delete_fs_snap </td>
-            <td>  bool </td>
-            <td> always </td>
-            <td> Whether or not the resource has deleted. </td>
-        </tr>
-                    <tr>
-            <td colspan=3 > modify_fs_snap </td>
-            <td>  bool </td>
-            <td> always </td>
-            <td> Whether or not the resource has modified. </td>
-        </tr>
-                    <tr>
-            <td colspan=3 > create_fs_snap </td>
-            <td>  bool </td>
-            <td> always </td>
-            <td> Whether or not the resource has created. </td>
-        </tr>
-                    <tr>
-            <td colspan=3 > filesystem_snap_details </td>
-            <td>  dict </td>
-            <td> When snapshot exists. </td>
-            <td> Details of the snapshot. </td>
-        </tr>
-                            <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > name </td>
-                <td> str </td>
-                <td>success</td>
-                <td> The name of the snapshot. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > creation_timestamp </td>
-                <td> str </td>
-                <td>success</td>
-                <td> The date and time the snapshot was created. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > id </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Unique identifier of the filesystem snapshot instance. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > parent_id </td>
-                <td> str </td>
-                <td>success</td>
-                <td> ID of the filesystem on which snapshot is taken. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > access_type </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Displays the type of access allowed to the snapshot. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > expiration_timestamp </td>
-                <td> str </td>
-                <td>success</td>
-                <td> The date and time the snapshot is due to be automatically deleted by the system. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > parent_name </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Name of the filesystem on which snapshot is taken. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > nas_server </td>
-                <td> dict </td>
-                <td>success</td>
-                <td> Details of NAS server on which snapshot is present. </td>
-            </tr>
-                                         <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=1 > name </td>
-                    <td> str </td>
-                    <td>success</td>
-                    <td> Name of the NAS server </td>
-                </tr>
-                                             <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=1 > id </td>
-                    <td> str </td>
-                    <td>success</td>
-                    <td> ID of the NAS server. </td>
-                </tr>
-                                                            <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > description </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Description of the filesystem snapshot. </td>
-            </tr>
-                                        <tr>
-            <td colspan=3 > changed </td>
+                                                                                            <tr>
+            <td colspan=4 > changed </td>
             <td>  bool </td>
             <td> always </td>
             <td> Whether or not the resource has changed. </td>
         </tr>
-                                                                            </table>
+                    <tr>
+            <td colspan=4 > create_vg_snap </td>
+            <td>  bool </td>
+            <td> When value exists </td>
+            <td> A boolean flag to indicate whether volume group snapshot got created. </td>
+        </tr>
+                    <tr>
+            <td colspan=4 > create_vol_snap </td>
+            <td>  bool </td>
+            <td> When value exists </td>
+            <td> A boolean flag to indicate whether volume snapshot got created. </td>
+        </tr>
+                    <tr>
+            <td colspan=4 > delete_vg_snap </td>
+            <td>  bool </td>
+            <td> When value exists </td>
+            <td> A boolean flag to indicate whether volume group snapshot got deleted. </td>
+        </tr>
+                    <tr>
+            <td colspan=4 > delete_vol_snap </td>
+            <td>  bool </td>
+            <td> When value exists </td>
+            <td> A boolean flag to indicate whether volume snapshot got deleted. </td>
+        </tr>
+                    <tr>
+            <td colspan=4 > modify_vg_snap </td>
+            <td>  bool </td>
+            <td> When value exists </td>
+            <td> A boolean flag to indicate whether volume group snapshot got modified. </td>
+        </tr>
+                    <tr>
+            <td colspan=4 > modify_vol_snap </td>
+            <td>  bool </td>
+            <td> When value exists </td>
+            <td> A boolean flag to indicate whether volume snapshot got modified. </td>
+        </tr>
+                    <tr>
+            <td colspan=4 > snap_details </td>
+            <td>  complex </td>
+            <td> When snapshot exists </td>
+            <td> Details of the snapshot. </td>
+        </tr>
+                            <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=3 > creation_timestamp </td>
+                <td> str </td>
+                <td>success</td>
+                <td> The creation timestamp of the snapshot. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=3 > description </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Description about the snapshot. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=3 > id </td>
+                <td> str </td>
+                <td>success</td>
+                <td> The system generated ID given to the snapshot. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=3 > name </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Name of the snapshot. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=3 > performance_policy_id </td>
+                <td> str </td>
+                <td>success</td>
+                <td> The performance policy for the snapshot. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=3 > protection_data </td>
+                <td> complex </td>
+                <td>success</td>
+                <td> The protection data of the snapshot. </td>
+            </tr>
+                                         <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=2 > expiration_timestamp </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> The expiration timestamp of the snapshot. </td>
+                </tr>
+                                                            <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=3 > protection_policy_id </td>
+                <td> str </td>
+                <td>success</td>
+                <td> The protection policy of the snapshot. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=3 > size </td>
+                <td> int </td>
+                <td>success</td>
+                <td> Size of the snapshot. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=3 > state </td>
+                <td> str </td>
+                <td>success</td>
+                <td> The state of the snapshot. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=3 > type </td>
+                <td> str </td>
+                <td>success</td>
+                <td> The type of the snapshot. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=3 > volumes </td>
+                <td> complex </td>
+                <td>success</td>
+                <td> The volumes details of the volume group snapshot. </td>
+            </tr>
+                                         <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=2 > id </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> The system generated ID given to the volume associated with the volume group. </td>
+                </tr>
+                                                                    </table>
 
 ### Authors
 * Rajshree Khare (@khareRajshree) <ansible.team@dell.com>
@@ -10993,37 +11542,29 @@ Snapshot Rule operations on a PowerStore storage system
         <th>Choices</th>
         <th width="80%">Description</th>
     </tr>
-                    <tr>
-            <td colspan=1 > timeout</td>
-            <td> int  </td>
-            <td></td>
-            <td> 120 </td>
-            <td></td>
-            <td> <br> Time after which the connection will get terminated.  <br> It is to be mentioned in seconds. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > state</td>
+                                                            <tr>
+            <td colspan=1 > name</td>
             <td> str  </td>
-            <td> True </td>
             <td></td>
-            <td> <ul> <li>present</li>  <li>absent</li> </ul></td>
-            <td> <br> String variable indicates the state of Snapshot rule.  <br> For "Delete" operation only, it should be set to "absent".  <br> For all Create, Modify or Get details operation it should be set to "present". </td>
+            <td></td>
+            <td></td>
+            <td> <br> String variable. Indicates the name of the Snapshot rule. </td>
         </tr>
                     <tr>
-            <td colspan=1 > desired_retention</td>
-            <td> int  </td>
+            <td colspan=1 > snapshotrule_id</td>
+            <td> str  </td>
             <td></td>
             <td></td>
             <td></td>
-            <td> <br> Integer variable. Indicates the desired Snapshot retention period.  <br> It is required when creating a new Snapshot rule. </td>
+            <td> <br> String variable. Indicates the ID of the Snapshot rule. </td>
         </tr>
                     <tr>
-            <td colspan=1 > port</td>
-            <td> int  </td>
+            <td colspan=1 > new_name</td>
+            <td> str  </td>
             <td></td>
             <td></td>
             <td></td>
-            <td> <br> Port number for the PowerStore array.  <br> If not passed, it will take 443 as default. </td>
+            <td> <br> String variable. Indicates the new name of the Snapshot rule.  <br> Used for renaming operation. </td>
         </tr>
                     <tr>
             <td colspan=1 > days_of_week</td>
@@ -11034,14 +11575,6 @@ Snapshot Rule operations on a PowerStore storage system
             <td> <br> List of strings to specify days of the week on which the Snapshot rule should be applied. Must be applied for Snapshot rules where the 'time_of_day' parameter is set.  <br> Optional for the Snapshot rule created with an interval. When 'days_of_week' is not specified for a new Snapshot rule, the rule is applied on every day of the week. </td>
         </tr>
                     <tr>
-            <td colspan=1 > time_of_day</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> String variable. Indicates the time of the day to take a daily Snapshot, with the format "hh:mm" in 24 hour time format.  <br> When creating a Snapshot rule, specify either "interval"or "time_of_day" but not both. </td>
-        </tr>
-                    <tr>
             <td colspan=1 > interval</td>
             <td> str  </td>
             <td></td>
@@ -11050,28 +11583,36 @@ Snapshot Rule operations on a PowerStore storage system
             <td> <br> String variable. Indicates the interval between Snapshots.  <br> When creating a Snapshot rule, specify either "interval" or "time_of_day", but not both. </td>
         </tr>
                     <tr>
-            <td colspan=1 > name</td>
+            <td colspan=1 > desired_retention</td>
+            <td> int  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Integer variable. Indicates the desired Snapshot retention period.  <br> It is required when creating a new Snapshot rule. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > time_of_day</td>
             <td> str  </td>
             <td></td>
             <td></td>
             <td></td>
-            <td> <br> String variable. Indicates the name of the Snapshot rule. </td>
+            <td> <br> String variable. Indicates the time of the day to take a daily Snapshot, with the format "hh:mm" in 24 hour time format.  <br> When creating a Snapshot rule, specify either "interval"or "time_of_day" but not both. </td>
         </tr>
                     <tr>
-            <td colspan=1 > user</td>
+            <td colspan=1 > delete_snaps</td>
+            <td> bool  </td>
+            <td></td>
+            <td> False </td>
+            <td></td>
+            <td> <br> Boolean variable to specify whether all Snapshots previously created by this rule should also be deleted when this rule is removed.  <br> True specifies to delete all previously created Snapshots by this rule while deleting this rule.  <br> False specifies to retain all previously created Snapshots while deleting this rule. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > state</td>
             <td> str  </td>
             <td> True </td>
             <td></td>
-            <td></td>
-            <td> <br> The username of the PowerStore host. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > new_name</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> String variable. Indicates the new name of the Snapshot rule.  <br> Used for renaming operation. </td>
+            <td> <ul> <li>present</li>  <li>absent</li> </ul></td>
+            <td> <br> String variable indicates the state of Snapshot rule.  <br> For "Delete" operation only, it should be set to "absent".  <br> For all Create, Modify or Get details operation it should be set to "present". </td>
         </tr>
                     <tr>
             <td colspan=1 > array_ip</td>
@@ -11090,12 +11631,12 @@ Snapshot Rule operations on a PowerStore storage system
             <td> <br> Boolean variable to specify whether to validate SSL certificate or not.  <br> True - indicates that the SSL certificate should be verified. Set the environment variable REQUESTS_CA_BUNDLE to the path of the SSL certificate.  <br> False - indicates that the SSL certificate should not be verified. </td>
         </tr>
                     <tr>
-            <td colspan=1 > snapshotrule_id</td>
+            <td colspan=1 > user</td>
             <td> str  </td>
+            <td> True </td>
             <td></td>
             <td></td>
-            <td></td>
-            <td> <br> String variable. Indicates the ID of the Snapshot rule. </td>
+            <td> <br> The username of the PowerStore host. </td>
         </tr>
                     <tr>
             <td colspan=1 > password</td>
@@ -11106,14 +11647,22 @@ Snapshot Rule operations on a PowerStore storage system
             <td> <br> The password of the PowerStore host. </td>
         </tr>
                     <tr>
-            <td colspan=1 > delete_snaps</td>
-            <td> bool  </td>
+            <td colspan=1 > timeout</td>
+            <td> int  </td>
             <td></td>
-            <td> False </td>
+            <td> 120 </td>
             <td></td>
-            <td> <br> Boolean variable to specify whether all Snapshots previously created by this rule should also be deleted when this rule is removed.  <br> True specifies to delete all previously created Snapshots by this rule while deleting this rule.  <br> False specifies to retain all previously created Snapshots while deleting this rule. </td>
+            <td> <br> Time after which the connection will get terminated.  <br> It is to be mentioned in seconds. </td>
         </tr>
-                                                                                            </table>
+                    <tr>
+            <td colspan=1 > port</td>
+            <td> int  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Port number for the PowerStore array.  <br> If not passed, it will take 443 as default. </td>
+        </tr>
+                                                    </table>
 
 ### Notes
 * The check_mode is not supported.
@@ -11212,7 +11761,7 @@ Snapshot Rule operations on a PowerStore storage system
         <th>Returned</th>
         <th width="100%">Description</th>
     </tr>
-                                    <tr>
+                                                                                            <tr>
             <td colspan=3 > changed </td>
             <td>  bool </td>
             <td> always </td>
@@ -11226,10 +11775,17 @@ Snapshot Rule operations on a PowerStore storage system
         </tr>
                             <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > name </td>
-                <td> str </td>
+                <td colspan=2 > days_of_week </td>
+                <td> list </td>
                 <td>success</td>
-                <td> Name of the snapshot rule. </td>
+                <td> List of string to specify days of the week on which the rule should be applied. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > desired_retention </td>
+                <td> int </td>
+                <td>success</td>
+                <td> Desired snapshot retention period. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
@@ -11240,10 +11796,17 @@ Snapshot Rule operations on a PowerStore storage system
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > desired_retention </td>
-                <td> int </td>
+                <td colspan=2 > interval </td>
+                <td> str </td>
                 <td>success</td>
-                <td> Desired snapshot retention period. </td>
+                <td> The interval between snapshots. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=2 > name </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Name of the snapshot rule. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
@@ -11255,41 +11818,27 @@ Snapshot Rule operations on a PowerStore storage system
                                          <tr>
                     <td class="elbow-placeholder">&nbsp;</td>
                     <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=1 > name </td>
-                    <td> str </td>
-                    <td>success</td>
-                    <td> Name of the protection policy in which the snapshot rule is selected. </td>
-                </tr>
-                                             <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
                     <td colspan=1 > id </td>
                     <td> str </td>
                     <td>success</td>
                     <td> The protection policy ID in which the snapshot rule is selected. </td>
                 </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=1 > name </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> Name of the protection policy in which the snapshot rule is selected. </td>
+                </tr>
                                                             <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > days_of_week </td>
-                <td> list </td>
-                <td>success</td>
-                <td> List of string to specify days of the week on which the rule should be applied. </td>
-            </tr>
-                                <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=2 > time_of_day </td>
                 <td> str </td>
                 <td>success</td>
                 <td> The time of the day to take a daily snapshot. </td>
             </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > interval </td>
-                <td> str </td>
-                <td>success</td>
-                <td> The interval between snapshots. </td>
-            </tr>
-                                                                                                </table>
+                                        </table>
 
 ### Authors
 * Arindam Datta (@dattaarindam) <ansible.team@dell.com>
@@ -11313,21 +11862,21 @@ Manage volumes on a PowerStore storage system
         <th>Choices</th>
         <th width="80%">Description</th>
     </tr>
-                    <tr>
-            <td colspan=1 > host</td>
+                                                            <tr>
+            <td colspan=1 > vol_name</td>
             <td> str  </td>
             <td></td>
             <td></td>
             <td></td>
-            <td> <br> Host to be mapped/unmapped to a volume. If not specified, an unmapped volume is created. Only one of the host or host group can be supplied in one call.  <br> To represent host, both name or ID can be used interchangeably. The module will detect both. </td>
+            <td> <br> Unique name of the volume. This value must contain 128 or fewer printable unicode characters.  <br> Required when creating a volume. All other functionalities on a volume are supported using volume name or ID. </td>
         </tr>
                     <tr>
-            <td colspan=1 > performance_policy</td>
+            <td colspan=1 > vg_name</td>
             <td> str  </td>
             <td></td>
             <td></td>
-            <td> <ul> <li>high</li>  <li>medium</li>  <li>low</li> </ul></td>
-            <td> <br> The performance_policy for the volume.  <br> A volume can be assigned a performance policy at the time of creation of the volume, or later as well.  <br> The policy can also be changed for a given volume, by simply passing the new value.  <br> Check examples for more clarity.  <br> If not given, performance policy will be 'medium'. </td>
+            <td></td>
+            <td> <br> The name of the volume group. A volume can optionally be assigned to a volume group at the time of creation.  <br> Use the Volume Group Module for modification of the assignment. </td>
         </tr>
                     <tr>
             <td colspan=1 > vol_id</td>
@@ -11338,20 +11887,60 @@ Manage volumes on a PowerStore storage system
             <td> <br> The 36 character long ID of the volume, automatically generated when a volume is created.  <br> Cannot be used while creating a volume. All other functionalities on a volume are supported using volume name or ID. </td>
         </tr>
                     <tr>
-            <td colspan=1 > password</td>
-            <td> str  </td>
-            <td> True </td>
+            <td colspan=1 > size</td>
+            <td> float  </td>
             <td></td>
             <td></td>
-            <td> <br> The password of the PowerStore host. </td>
+            <td></td>
+            <td> <br> Size of the volume. Minimum volume size is 1MB. Maximum volume size is 256TB. Size must be a multiple of 8192.  <br> Required in case of create and expand volume. </td>
         </tr>
                     <tr>
-            <td colspan=1 > state</td>
+            <td colspan=1 > cap_unit</td>
             <td> str  </td>
-            <td> True </td>
             <td></td>
-            <td> <ul> <li>absent</li>  <li>present</li> </ul></td>
-            <td> <br> Define whether the volume should exist or not.  <br> Value present - indicates that the volume should exist on the system.  <br> Value absent - indicates that the volume should not exist on the system. </td>
+            <td></td>
+            <td> <ul> <li>MB</li>  <li>GB</li>  <li>TB</li> </ul></td>
+            <td> <br> Volume size unit.  <br> Used to signify unit of the size provided for creation and expansion of volume.  <br> It defaults to 'GB', if not specified. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > new_name</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> The new volume name for the volume, used in case of rename functionality. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > description</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Description for the volume.  <br> Optional parameter when creating a volume.  <br> To modify, pass the new value in description field. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > protection_policy</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> The protection_policy of the volume.  <br> To represent policy, both name or ID can be used interchangably. The module will detect both.  <br> A volume can be assigned a protection policy at the time of creation of volume or later as well.  <br> The policy can also be changed for a given volume by simply passing the new value.  <br> The policy can be removed by passing an empty string.  <br> Check examples for more clarity. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > performance_policy</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td> <ul> <li>high</li>  <li>medium</li>  <li>low</li> </ul></td>
+            <td> <br> The performance_policy for the volume.  <br> A volume can be assigned a performance policy at the time of creation of the volume, or later as well.  <br> The policy can also be changed for a given volume, by simply passing the new value.  <br> Check examples for more clarity.  <br> If not given, performance policy will be 'medium'. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > host</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Host to be mapped/unmapped to a volume. If not specified, an unmapped volume is created. Only one of the host or host group can be supplied in one call.  <br> To represent host, both name or ID can be used interchangeably. The module will detect both. </td>
         </tr>
                     <tr>
             <td colspan=1 > hostgroup</td>
@@ -11370,14 +11959,6 @@ Manage volumes on a PowerStore storage system
             <td> <br> Define whether the volume should be mapped to a host or hostgroup.  <br> Value mapped - indicates that the volume should be mapped to the host or host group.  <br> Value unmapped - indicates that the volume should not be mapped to the host or host group.  <br> Only one of a host or host group can be supplied in one call. </td>
         </tr>
                     <tr>
-            <td colspan=1 > port</td>
-            <td> int  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Port number for the PowerStore array.  <br> If not passed, it will take 443 as default. </td>
-        </tr>
-                    <tr>
             <td colspan=1 > hlu</td>
             <td> int  </td>
             <td></td>
@@ -11386,52 +11967,12 @@ Manage volumes on a PowerStore storage system
             <td> <br> Logical unit number for the host/host group volume access.  <br> Optional parameter when mapping a volume to host/host group.  <br> HLU modification is not supported. </td>
         </tr>
                     <tr>
-            <td colspan=1 > new_name</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> The new volume name for the volume, used in case of rename functionality. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > vol_name</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Unique name of the volume. This value must contain 128 or fewer printable unicode characters.  <br> Required when creating a volume. All other functionalities on a volume are supported using volume name or ID. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > timeout</td>
-            <td> int  </td>
-            <td></td>
-            <td> 120 </td>
-            <td></td>
-            <td> <br> Time after which the connection will get terminated.  <br> It is to be mentioned in seconds. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > vg_name</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> The name of the volume group. A volume can optionally be assigned to a volume group at the time of creation.  <br> Use the Volume Group Module for modification of the assignment. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > user</td>
+            <td colspan=1 > state</td>
             <td> str  </td>
             <td> True </td>
             <td></td>
-            <td></td>
-            <td> <br> The username of the PowerStore host. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > cap_unit</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td> <ul> <li>MB</li>  <li>GB</li>  <li>TB</li> </ul></td>
-            <td> <br> Volume size unit.  <br> Used to signify unit of the size provided for creation and expansion of volume.  <br> It defaults to 'GB', if not specified. </td>
+            <td> <ul> <li>absent</li>  <li>present</li> </ul></td>
+            <td> <br> Define whether the volume should exist or not.  <br> Value present - indicates that the volume should exist on the system.  <br> Value absent - indicates that the volume should not exist on the system. </td>
         </tr>
                     <tr>
             <td colspan=1 > array_ip</td>
@@ -11442,14 +11983,6 @@ Manage volumes on a PowerStore storage system
             <td> <br> IP or FQDN of the PowerStore management system. </td>
         </tr>
                     <tr>
-            <td colspan=1 > protection_policy</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> The protection_policy of the volume.  <br> To represent policy, both name or ID can be used interchangably. The module will detect both.  <br> A volume can be assigned a protection policy at the time of creation of volume or later as well.  <br> The policy can also be changed for a given volume by simply passing the new value.  <br> The policy can be removed by passing an empty string.  <br> Check examples for more clarity. </td>
-        </tr>
-                    <tr>
             <td colspan=1 > verifycert</td>
             <td> bool  </td>
             <td> True </td>
@@ -11458,22 +11991,38 @@ Manage volumes on a PowerStore storage system
             <td> <br> Boolean variable to specify whether to validate SSL certificate or not.  <br> True - indicates that the SSL certificate should be verified. Set the environment variable REQUESTS_CA_BUNDLE to the path of the SSL certificate.  <br> False - indicates that the SSL certificate should not be verified. </td>
         </tr>
                     <tr>
-            <td colspan=1 > size</td>
-            <td> float  </td>
+            <td colspan=1 > user</td>
+            <td> str  </td>
+            <td> True </td>
             <td></td>
             <td></td>
-            <td></td>
-            <td> <br> Size of the volume. Minimum volume size is 1MB. Maximum volume size is 256TB. Size must be a multiple of 8192.  <br> Required in case of create and expand volume. </td>
+            <td> <br> The username of the PowerStore host. </td>
         </tr>
                     <tr>
-            <td colspan=1 > description</td>
+            <td colspan=1 > password</td>
             <td> str  </td>
+            <td> True </td>
             <td></td>
             <td></td>
-            <td></td>
-            <td> <br> Description for the volume.  <br> Optional parameter when creating a volume.  <br> To modify, pass the new value in description field. </td>
+            <td> <br> The password of the PowerStore host. </td>
         </tr>
-                                                                                            </table>
+                    <tr>
+            <td colspan=1 > timeout</td>
+            <td> int  </td>
+            <td></td>
+            <td> 120 </td>
+            <td></td>
+            <td> <br> Time after which the connection will get terminated.  <br> It is to be mentioned in seconds. </td>
+        </tr>
+                    <tr>
+            <td colspan=1 > port</td>
+            <td> int  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Port number for the PowerStore array.  <br> If not passed, it will take 443 as default. </td>
+        </tr>
+                                                    </table>
 
 ### Notes
 * To create a new volume, vol_name and size is required. cap_unit, description, vg_name, performance_policy, and protection_policy are optional.
@@ -11620,7 +12169,7 @@ Manage volumes on a PowerStore storage system
         <th>Returned</th>
         <th width="100%">Description</th>
     </tr>
-                                    <tr>
+                                                                                            <tr>
             <td colspan=7 > changed </td>
             <td>  bool </td>
             <td> always </td>
@@ -11634,51 +12183,12 @@ Manage volumes on a PowerStore storage system
         </tr>
                             <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=6 > volume_groups </td>
-                <td> complex </td>
+                <td colspan=6 > description </td>
+                <td> str </td>
                 <td>success</td>
-                <td> The volume group details of the volume. </td>
+                <td> description about the volume. </td>
             </tr>
-                                         <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=5 > name </td>
-                    <td> str </td>
-                    <td>success</td>
-                    <td> Name of the volume group. </td>
-                </tr>
-                                             <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=5 > id </td>
-                    <td> str </td>
-                    <td>success</td>
-                    <td> The system generated ID given to the volume group. </td>
-                </tr>
-                                                            <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=6 > host </td>
-                <td> complex </td>
-                <td>success</td>
-                <td> Hosts details mapped to the volume. </td>
-            </tr>
-                                         <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=5 > name </td>
-                    <td> str </td>
-                    <td>success</td>
-                    <td> Name of the Host mapped to the volume. </td>
-                </tr>
-                                             <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=5 > id </td>
-                    <td> str </td>
-                    <td>success</td>
-                    <td> The host ID mapped to the volume. </td>
-                </tr>
-                                                            <tr>
+                                <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=6 > hlu_details </td>
                 <td> complex </td>
@@ -11696,6 +12206,14 @@ Manage volumes on a PowerStore storage system
                                              <tr>
                     <td class="elbow-placeholder">&nbsp;</td>
                     <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=5 > host_id </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> The host ID mapped to the volume. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
                     <td colspan=5 > id </td>
                     <td> str </td>
                     <td>success</td>
@@ -11709,64 +12227,30 @@ Manage volumes on a PowerStore storage system
                     <td>success</td>
                     <td> Logical unit number for the host/host group volume access. </td>
                 </tr>
-                                             <tr>
+                                                            <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=6 > host </td>
+                <td> complex </td>
+                <td>success</td>
+                <td> Hosts details mapped to the volume. </td>
+            </tr>
+                                         <tr>
                     <td class="elbow-placeholder">&nbsp;</td>
                     <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=5 > host_id </td>
+                    <td colspan=5 > id </td>
                     <td> str </td>
                     <td>success</td>
                     <td> The host ID mapped to the volume. </td>
                 </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=5 > name </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> Name of the Host mapped to the volume. </td>
+                </tr>
                                                             <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=6 > wwn </td>
-                <td> str </td>
-                <td>success</td>
-                <td> The world wide name of the volume. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=6 > protection_policy_id </td>
-                <td> str </td>
-                <td>success</td>
-                <td> The protection policy of the volume. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=6 > performance_policy_id </td>
-                <td> str </td>
-                <td>success</td>
-                <td> The performance policy for the volume. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=6 > nsid </td>
-                <td> int </td>
-                <td>success</td>
-                <td> NVMe Namespace unique identifier in the NVME subsystem. Used for volumes attached to NVMEoF hosts. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=6 > nguid </td>
-                <td> int </td>
-                <td>success</td>
-                <td> NVMe Namespace globally unique identifier. Used for volumes attached to NVMEoF hosts. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=6 > name </td>
-                <td> str </td>
-                <td>success</td>
-                <td> Name of the volume. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=6 > id </td>
-                <td> str </td>
-                <td>success</td>
-                <td> The system generated ID given to the volume. </td>
-            </tr>
-                                <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=6 > host_group </td>
                 <td> complex </td>
@@ -11776,20 +12260,27 @@ Manage volumes on a PowerStore storage system
                                          <tr>
                     <td class="elbow-placeholder">&nbsp;</td>
                     <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=5 > name </td>
-                    <td> str </td>
-                    <td>success</td>
-                    <td> Name of the Host group mapped to the volume. </td>
-                </tr>
-                                             <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
                     <td colspan=5 > id </td>
                     <td> str </td>
                     <td>success</td>
                     <td> The host group ID mapped to the volume. </td>
                 </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=5 > name </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> Name of the Host group mapped to the volume. </td>
+                </tr>
                                                             <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=6 > id </td>
+                <td> str </td>
+                <td>success</td>
+                <td> The system generated ID given to the volume. </td>
+            </tr>
+                                <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
                 <td colspan=6 > mapped_volumes </td>
                 <td> complex </td>
@@ -11814,17 +12305,17 @@ Manage volumes on a PowerStore storage system
                 </tr>
                                                             <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=6 > size </td>
-                <td> int </td>
+                <td colspan=6 > name </td>
+                <td> str </td>
                 <td>success</td>
-                <td> Size of the volume. </td>
+                <td> Name of the volume. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=6 > description </td>
-                <td> str </td>
+                <td colspan=6 > nguid </td>
+                <td> int </td>
                 <td>success</td>
-                <td> description about the volume. </td>
+                <td> NVMe Namespace globally unique identifier. Used for volumes attached to NVMEoF hosts. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
@@ -11833,7 +12324,65 @@ Manage volumes on a PowerStore storage system
                 <td>success</td>
                 <td> This attribute shows which node will be advertised as the optimized IO path to the volume. </td>
             </tr>
-                                                                                                </table>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=6 > nsid </td>
+                <td> int </td>
+                <td>success</td>
+                <td> NVMe Namespace unique identifier in the NVME subsystem. Used for volumes attached to NVMEoF hosts. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=6 > performance_policy_id </td>
+                <td> str </td>
+                <td>success</td>
+                <td> The performance policy for the volume. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=6 > protection_policy_id </td>
+                <td> str </td>
+                <td>success</td>
+                <td> The protection policy of the volume. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=6 > size </td>
+                <td> int </td>
+                <td>success</td>
+                <td> Size of the volume. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=6 > volume_groups </td>
+                <td> complex </td>
+                <td>success</td>
+                <td> The volume group details of the volume. </td>
+            </tr>
+                                         <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=5 > id </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> The system generated ID given to the volume group. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=5 > name </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> Name of the volume group. </td>
+                </tr>
+                                                            <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=6 > wwn </td>
+                <td> str </td>
+                <td>success</td>
+                <td> The world wide name of the volume. </td>
+            </tr>
+                                        </table>
 
 ### Authors
 * Ambuj Dubey (@AmbujDube) <ansible.team@dell.com>
@@ -11845,62 +12394,22 @@ Manage volumes on a PowerStore storage system
 Manage volume groups on a PowerStore Storage System
 
 ### Synopsis
- Managing volume group on PowerStore Storage System includes creating new volume group, adding volumes to volume group, removing volumes from volume group.
+ Managing volume group on PowerStore Storage System includes creating new volume group, adding volumes to volume group, removing volumes from volume group, clone of a volume group, refresh of a volume group and restore of volume group.
  Module also include renaming volume group, modifying volume group, and deleting volume group.
 
 ### Parameters
-                                                                                                                                                                                                                                                                                                                                                            
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        
 <table>
     <tr>
-        <th colspan=1>Parameter</th>
+        <th colspan=2>Parameter</th>
         <th width="20%">Type</th>
         <th>Required</th>
         <th>Default</th>
         <th>Choices</th>
         <th width="80%">Description</th>
     </tr>
-                    <tr>
-            <td colspan=1 > vg_id</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> The id of the volume group.  <br> It can be used only for Modify, Add/Remove, or Delete operation. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > port</td>
-            <td> int  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> Port number for the PowerStore array.  <br> If not passed, it will take 443 as default. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > volumes</td>
-            <td> list   <br> elements: str </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> This is a list of volumes.  <br> Either the volume ID or name must be provided for adding/removing existing volumes from a volume group.  <br> If volumes are given, then vol_state should also be specified. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > vol_state</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td> <ul> <li>present-in-group</li>  <li>absent-in-group</li> </ul></td>
-            <td> <br> String variable. Describes the state of volumes inside a volume group.  <br> If volume is given, then vol_state should also be specified. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > timeout</td>
-            <td> int  </td>
-            <td></td>
-            <td> 120 </td>
-            <td></td>
-            <td> <br> Time after which the connection will get terminated.  <br> It is to be mentioned in seconds. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > vg_name</td>
+                                                            <tr>
+            <td colspan=2 > vg_name</td>
             <td> str  </td>
             <td></td>
             <td></td>
@@ -11908,7 +12417,31 @@ Manage volume groups on a PowerStore Storage System
             <td> <br> The name of the volume group. </td>
         </tr>
                     <tr>
-            <td colspan=1 > new_vg_name</td>
+            <td colspan=2 > vg_id</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> The id of the volume group.  <br> It can be used only for Modify, Add/Remove, or Delete operation. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > volumes</td>
+            <td> list   <br> elements: str </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> This is a list of volumes.  <br> Either the volume ID or name must be provided for adding/removing existing volumes from a volume group.  <br> If volumes are given, then vol_state should also be specified. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > vol_state</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td> <ul> <li>present-in-group</li>  <li>absent-in-group</li> </ul></td>
+            <td> <br> String variable. Describes the state of volumes inside a volume group.  <br> If volume is given, then vol_state should also be specified. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > new_vg_name</td>
             <td> str  </td>
             <td></td>
             <td></td>
@@ -11916,47 +12449,7 @@ Manage volume groups on a PowerStore Storage System
             <td> <br> The new name of the volume group. </td>
         </tr>
                     <tr>
-            <td colspan=1 > user</td>
-            <td> str  </td>
-            <td> True </td>
-            <td></td>
-            <td></td>
-            <td> <br> The username of the PowerStore host. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > protection_policy</td>
-            <td> str  </td>
-            <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> String variable. Represents Protection policy id or name used for volume group.  <br> Specifying an empty string or "" removes the existing protection policy from volume group. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > verifycert</td>
-            <td> bool  </td>
-            <td> True </td>
-            <td></td>
-            <td> <ul> <li>True</li>  <li>False</li> </ul></td>
-            <td> <br> Boolean variable to specify whether to validate SSL certificate or not.  <br> True - indicates that the SSL certificate should be verified. Set the environment variable REQUESTS_CA_BUNDLE to the path of the SSL certificate.  <br> False - indicates that the SSL certificate should not be verified. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > state</td>
-            <td> str  </td>
-            <td> True </td>
-            <td></td>
-            <td> <ul> <li>absent</li>  <li>present</li> </ul></td>
-            <td> <br> Define whether the volume group should exist or not. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > password</td>
-            <td> str  </td>
-            <td> True </td>
-            <td></td>
-            <td></td>
-            <td> <br> The password of the PowerStore host. </td>
-        </tr>
-                    <tr>
-            <td colspan=1 > description</td>
+            <td colspan=2 > description</td>
             <td> str  </td>
             <td></td>
             <td></td>
@@ -11964,7 +12457,125 @@ Manage volume groups on a PowerStore Storage System
             <td> <br> Description about the volume group. </td>
         </tr>
                     <tr>
-            <td colspan=1 > array_ip</td>
+            <td colspan=2 > protection_policy</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> String variable. Represents Protection policy id or name used for volume group.  <br> Specifying an empty string or "" removes the existing protection policy from volume group. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > is_write_order_consistent</td>
+            <td> bool  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> A boolean flag to indicate whether Snapshot sets of the volume group will be write-order consistent.  <br> If this parameter is not specified, the array by default sets it to true. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > source_vg</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> ID or name of the volume group to refresh from. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > source_snap</td>
+            <td> str  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> ID or name of the snapshot to restore from. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > create_backup_snap</td>
+            <td> bool  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Specifies whether a backup snapshot set of the target volume group needs to be created before attempting refresh or restore.  <br> If not specified it will be set to True. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > backup_snap_profile</td>
+            <td> dict  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Snapshot volume group request. </td>
+        </tr>
+                            <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > name </td>
+                <td> str  </td>
+                <td> True </td>
+                <td></td>
+                <td></td>
+                <td>  <br> Name of snapshot set to be created.  </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > description </td>
+                <td> str  </td>
+                <td></td>
+                <td></td>
+                <td></td>
+                <td>  <br> Description of the snapshot set.  </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > expiration_timestamp </td>
+                <td> str  </td>
+                <td></td>
+                <td></td>
+                <td></td>
+                <td>  <br> Time after which the snapshot set can be auto-purged.  </td>
+            </tr>
+                                        <tr>
+            <td colspan=2 > vg_clone</td>
+            <td> dict  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Parameters to support clone of a volume group. </td>
+        </tr>
+                            <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > name </td>
+                <td> str  </td>
+                <td> True </td>
+                <td></td>
+                <td></td>
+                <td>  <br> Name for the clone volume group.  </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > description </td>
+                <td> str  </td>
+                <td></td>
+                <td></td>
+                <td></td>
+                <td>  <br> Description for the clone volume group.  </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=1 > protection_policy </td>
+                <td> str  </td>
+                <td></td>
+                <td></td>
+                <td></td>
+                <td>  <br> ID or name of the protection policy to assign to the clone volume.  </td>
+            </tr>
+                                        <tr>
+            <td colspan=2 > state</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td> <ul> <li>absent</li>  <li>present</li> </ul></td>
+            <td> <br> Define whether the volume group should exist or not. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > array_ip</td>
             <td> str  </td>
             <td> True </td>
             <td></td>
@@ -11972,14 +12583,46 @@ Manage volume groups on a PowerStore Storage System
             <td> <br> IP or FQDN of the PowerStore management system. </td>
         </tr>
                     <tr>
-            <td colspan=1 > is_write_order_consistent</td>
+            <td colspan=2 > verifycert</td>
             <td> bool  </td>
+            <td> True </td>
             <td></td>
-            <td></td>
-            <td></td>
-            <td> <br> A boolean flag to indicate whether Snapshot sets of the volume group will be write-order consistent.  <br> If this parameter is not specified, the array by default sets it to true. </td>
+            <td> <ul> <li>True</li>  <li>False</li> </ul></td>
+            <td> <br> Boolean variable to specify whether to validate SSL certificate or not.  <br> True - indicates that the SSL certificate should be verified. Set the environment variable REQUESTS_CA_BUNDLE to the path of the SSL certificate.  <br> False - indicates that the SSL certificate should not be verified. </td>
         </tr>
-                                                                                            </table>
+                    <tr>
+            <td colspan=2 > user</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td></td>
+            <td> <br> The username of the PowerStore host. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > password</td>
+            <td> str  </td>
+            <td> True </td>
+            <td></td>
+            <td></td>
+            <td> <br> The password of the PowerStore host. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > timeout</td>
+            <td> int  </td>
+            <td></td>
+            <td> 120 </td>
+            <td></td>
+            <td> <br> Time after which the connection will get terminated.  <br> It is to be mentioned in seconds. </td>
+        </tr>
+                    <tr>
+            <td colspan=2 > port</td>
+            <td> int  </td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td> <br> Port number for the PowerStore array.  <br> If not passed, it will take 443 as default. </td>
+        </tr>
+                                                    </table>
 
 ### Notes
 * Parameter vol_state is mandatory if volumes are provided.
@@ -12065,65 +12708,165 @@ Manage volume groups on a PowerStore Storage System
     password: "{{password}}"
     name: "{{new_vg_name}}"
     state: "absent"
+
+- name: Refresh a volume group
+  dellemc.powerstore.volumegroup:
+    array_ip: "{{array_ip}}"
+    verifycert: "{{verifycert}}"
+    user: "{{user}}"
+    password: "{{password}}"
+    vg_name: "ansible_vg"
+    source_vg: "vg_source"
+    create_backup_snap: True
+    backup_snap_profile:
+        name: "test_snap"
+    state: "present"
+
+- name: Restore a volume group
+  dellemc.powerstore.volumegroup:
+    array_ip: "{{array_ip}}"
+    verifycert: "{{verifycert}}"
+    user: "{{user}}"
+    password: "{{password}}"
+    vg_name: "ansible_vg"
+    source_snap: "snap_source"
+    create_backup_snap: True
+    backup_snap_profile:
+        name: "test_snap_restore"
+    state: "present"
+
+- name: Clone a volume group
+  dellemc.powerstore.volumegroup:
+    array_ip: "{{array_ip}}"
+    verifycert: "{{verifycert}}"
+    user: "{{user}}"
+    password: "{{password}}"
+    vg_name: "ansible_vg"
+    vg_clone:
+        name: "ansible_vg_clone"
+        protection_policy: "policy1"
+    state: "present"
 ```
 
 ### Return Values
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            
 <table>
     <tr>
-        <th colspan=3>Key</th>
+        <th colspan=4>Key</th>
         <th>Type</th>
         <th>Returned</th>
         <th width="100%">Description</th>
     </tr>
-                                    <tr>
-            <td colspan=3 > delete_vg </td>
-            <td>  bool </td>
-            <td> When value exists </td>
-            <td> A boolean flag to indicate whether volume group got deleted. </td>
-        </tr>
-                    <tr>
-            <td colspan=3 > add_vols_to_vg </td>
+                                                                                            <tr>
+            <td colspan=4 > add_vols_to_vg </td>
             <td>  bool </td>
             <td> When value exists </td>
             <td> A boolean flag to indicate whether volume/s got added to volume group. </td>
         </tr>
                     <tr>
-            <td colspan=3 > remove_vols_from_vg </td>
+            <td colspan=4 > changed </td>
+            <td>  bool </td>
+            <td> always </td>
+            <td> Whether or not the resource has changed. </td>
+        </tr>
+                    <tr>
+            <td colspan=4 > create_vg </td>
+            <td>  bool </td>
+            <td> When value exists </td>
+            <td> A boolean flag to indicate whether volume group got created. </td>
+        </tr>
+                    <tr>
+            <td colspan=4 > delete_vg </td>
+            <td>  bool </td>
+            <td> When value exists </td>
+            <td> A boolean flag to indicate whether volume group got deleted. </td>
+        </tr>
+                    <tr>
+            <td colspan=4 > modify_vg </td>
+            <td>  bool </td>
+            <td> When value exists </td>
+            <td> A boolean flag to indicate whether volume group got modified. </td>
+        </tr>
+                    <tr>
+            <td colspan=4 > remove_vols_from_vg </td>
             <td>  bool </td>
             <td> When value exists </td>
             <td> A boolean flag to indicate whether volume/s got removed from volume group. </td>
         </tr>
                     <tr>
-            <td colspan=3 > volume_group_details </td>
+            <td colspan=4 > volume_group_details </td>
             <td>  complex </td>
             <td> When volume group exists </td>
             <td> Details of the volume group. </td>
         </tr>
                             <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > name </td>
+                <td colspan=3 > description </td>
                 <td> str </td>
                 <td>success</td>
-                <td> Name of the volume group. </td>
+                <td> description about the volume group. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > id </td>
+                <td colspan=3 > id </td>
                 <td> str </td>
                 <td>success</td>
                 <td> The system generated ID given to the volume group. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > is_write_order_consistent </td>
+                <td colspan=3 > is_write_order_consistent </td>
                 <td> bool </td>
                 <td>success</td>
                 <td> A boolean flag to indicate whether snapshot sets of the volume group will be write-order consistent. </td>
             </tr>
                                 <tr>
                 <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > volumes </td>
+                <td colspan=3 > name </td>
+                <td> str </td>
+                <td>success</td>
+                <td> Name of the volume group. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=3 > protection_policy_id </td>
+                <td> str </td>
+                <td>success</td>
+                <td> The protection policy of the volume group. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=3 > snapshots </td>
+                <td> complex </td>
+                <td>success</td>
+                <td> The snapshots associated with the volume group. </td>
+            </tr>
+                                         <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=2 > id </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> ID of the snapshot. </td>
+                </tr>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=2 > name </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> Name of the snapshot. </td>
+                </tr>
+                                                            <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=3 > type </td>
+                <td> str </td>
+                <td>success</td>
+                <td> The type of the volume group. </td>
+            </tr>
+                                <tr>
+                <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan=3 > volumes </td>
                 <td> complex </td>
                 <td>success</td>
                 <td> The volumes details of the volume group. </td>
@@ -12131,59 +12874,20 @@ Manage volume groups on a PowerStore Storage System
                                          <tr>
                     <td class="elbow-placeholder">&nbsp;</td>
                     <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=1 > name </td>
-                    <td> str </td>
-                    <td>success</td>
-                    <td> The name of the volume associated with the volume group. </td>
-                </tr>
-                                             <tr>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td class="elbow-placeholder">&nbsp;</td>
-                    <td colspan=1 > id </td>
+                    <td colspan=2 > id </td>
                     <td> str </td>
                     <td>success</td>
                     <td> The system generated ID given to the volume associated with the volume group. </td>
                 </tr>
-                                                            <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > type </td>
-                <td> str </td>
-                <td>success</td>
-                <td> The type of the volume group. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > protection_policy_id </td>
-                <td> str </td>
-                <td>success</td>
-                <td> The protection policy of the volume group. </td>
-            </tr>
-                                <tr>
-                <td class="elbow-placeholder">&nbsp;</td>
-                <td colspan=2 > description </td>
-                <td> str </td>
-                <td>success</td>
-                <td> description about the volume group. </td>
-            </tr>
-                                        <tr>
-            <td colspan=3 > changed </td>
-            <td>  bool </td>
-            <td> always </td>
-            <td> Whether or not the resource has changed. </td>
-        </tr>
-                    <tr>
-            <td colspan=3 > create_vg </td>
-            <td>  bool </td>
-            <td> When value exists </td>
-            <td> A boolean flag to indicate whether volume group got created. </td>
-        </tr>
-                    <tr>
-            <td colspan=3 > modify_vg </td>
-            <td>  bool </td>
-            <td> When value exists </td>
-            <td> A boolean flag to indicate whether volume group got modified. </td>
-        </tr>
-                                                                            </table>
+                                             <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                    <td colspan=2 > name </td>
+                    <td> str </td>
+                    <td>success</td>
+                    <td> The name of the volume associated with the volume group. </td>
+                </tr>
+                                                                    </table>
 
 ### Authors
 * Akash Shendge (@shenda1) <ansible.team@dell.com>

--- a/docs/Release Notes.md
+++ b/docs/Release Notes.md
@@ -1,6 +1,6 @@
 **Ansible Modules for Dell Technologies PowerStore**
 =========================================
-### Release Notes 1.6.0
+### Release Notes 1.7.0
 
 >   © 2022 Dell Inc. or its subsidiaries. All rights reserved. Dell,
 >   and other trademarks are trademarks of Dell Inc. or its
@@ -28,7 +28,7 @@ Table 1. Revision history
 
 | Revision | Date      | Description                                               |
 |----------|-----------|-----------------------------------------------------------|
-| 01       | June 2022  | Current release of Ansible Modules for Dell PowerStore 1.6.0 |
+| 01       | September 2022  | Current release of Ansible Modules for Dell PowerStore 1.7.0 |
 
 Product Description
 -------------------
@@ -36,48 +36,38 @@ The Ansible modules for Dell PowerStore are used to automate and orchestrate the
 
 New features & enhancements
 ---------------------------
-Along with the previous release deliverables, this release supports these features -
+Along with the previous release deliverables, this release supports these features:
 
--   LDAP account module supports these functionalities:
-    -   Get LDAP account details.
-    -   Create an LDAP account.
-    -   Modify attributes of an LDAP account.
-    -   Delete an LDAP account.
-
--   LDAP domain module supports these functionalities:
-    -   Get LDAP domain configuration details.
-    -   Configure an LDAP domain.
-    -   Modify attributes of an LDAP domain configuration.
-    -   Verify an LDAP domain configuration.
-    -   Delete an LDAP domain configuration.
-    
--   Info module has these enhancements:
-    -  List of LDAP accounts.
-    -  List of LDAP domain configurations.
-    -  Enabled check mode support.
-    
-- Added execution environment manifest file to support building an execution environment with ansible-builder.
+- Cluster module is enhanced to create a cluster and validate the cluster create attributes.
+- NAS server module is enhanced to support the following functionalities:
+    - Associate a protection policy to a NAS server
+    - Disassociate a protection policy from a NAS server.
+- Replication session module is enhanced to support filesystem and NAS server replication sessions.
+- Volume group is enhanced to support the following functionalities:
+    -  Clone a volume group.
+    -  Refresh a volume group.
+    -  Restore a volume group.
 
 Known issues
 ------------
-There are no known issues.
+Hosts in IPv4/prefix_length format do not get mapped to an NFS export in Foothills Prime version of PowerStore.
 
 Limitations
 -----------
--   All occurrences of Password and related parameters do not support Idempotency.
--   Exchange, reset and add/import of certificates do not support Idempotency.
--   Verify connection  and send test alert for remote support module do not support Idempotency.
--   Sending test alert through SMTP configuration and Email module does not support Idempotency.
--   Verify operation for LDAP domain module does not support Idempotency.
+- All occurrences of Password and related parameters do not support Idempotency.
+- Exchange, reset and add/import of certificates do not support Idempotency.
+- Verify connection  and send test alert for remote support module do not support Idempotency.
+- Sending test alert through SMTP configuration and Email module does not support Idempotency.
+- Verify operation for LDAP domain module does not support Idempotency.
 
 Distribution
 ----------------
 The software package is available for download from the [Ansible Modules
-for PowerStore GitHub](https://github.com/dell/ansible-powerstore/tree/1.6.0) page.
+for PowerStore GitHub](https://github.com/dell/ansible-powerstore/tree/1.7.0) page.
 
 Documentation
 -------------
-The documentation is available on [Ansible Modules for PowerStore GitHub](https://github.com/dell/ansible-powerstore/tree/1.6.0/docs)
+The documentation is available on [Ansible Modules for PowerStore GitHub](https://github.com/dell/ansible-powerstore/tree/1.7.0/docs)
 page. It includes these:
 - README
 - Release Notes (this document)

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,0 +1,22 @@
+<!--
+Copyright (c) 2022 Dell Inc., or its subsidiaries. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+-->
+
+# Security policy
+
+The Ansible modules for Dell PowerStore repository are inspected for security vulnerabilities via blackduck scans and static code analysis.
+
+In addition to this, there are various security checks that get executed against a branch when a pull request is created/updated.  Please refer to [pull request](https://github.com/dell/ansible-powerstore/blob/1.7.0/docs/CONTRIBUTING.md#Pull-requests) for more information.
+
+## Reporting a vulnerability
+
+Have you discovered a security vulnerability in this project?
+We ask you to alert the maintainers by sending an email, describing the issue, impact, and fix - if applicable.
+
+You can reach the Ansible modules for Dell PowerStore maintainers at ansible.team@dell.com.

--- a/docs/SUPPORT.md
+++ b/docs/SUPPORT.md
@@ -1,0 +1,12 @@
+<!--
+Copyright (c) 2022 Dell Inc., or its subsidiaries. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+-->
+
+## Support
+For all your support needs you can interact with us on [GitHub](https://github.com/dell/ansible-powerstore) by creating a [GitHub Issue](https://github.com/dell/ansible-powerstore/issues) or through the [Ansible Community](https://www.dell.com/community/Automation/bd-p/Automation).

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ namespace: dellemc
 name: powerstore
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.6.0
+version: 1.7.0
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md
@@ -52,13 +52,13 @@ tags: [storage]
 dependencies: {}
 
 # The URL of the originating SCM repository
-repository: https://github.com/dell/ansible-powerstore/tree/1.6.0
+repository: https://github.com/dell/ansible-powerstore/tree/1.7.0
 
 # The URL to any online docs
-documentation: https://github.com/dell/ansible-powerstore/tree/1.6.0/docs
+documentation: https://github.com/dell/ansible-powerstore/tree/1.7.0/docs
 
 # The URL to the homepage of the collection/project
-homepage: https://github.com/dell/ansible-powerstore/tree/1.6.0
+homepage: https://github.com/dell/ansible-powerstore/tree/1.7.0
 
 # The URL to the collection issue tracker
 issues: https://www.dell.com/community/Automation/bd-p/Automation

--- a/meta/execution-environment.yml
+++ b/meta/execution-environment.yml
@@ -1,5 +1,5 @@
 ---
 version: 1
 dependencies:
-  galaxy: ../requirements.yml # Absolute/relative path of requirements.yml
-  python: ../requirements.txt # Absolute/relative path of requirements.txt
+  galaxy: requirements.yml # Absolute/relative path of requirements.yml
+  python: requirements.txt # Absolute/relative path of requirements.txt

--- a/plugins/module_utils/storage/dell/utils.py
+++ b/plugins/module_utils/storage/dell/utils.py
@@ -31,6 +31,7 @@ import logging
 import math
 from decimal import Decimal
 from uuid import UUID
+from datetime import datetime
 
 '''
 Check required libraries
@@ -62,7 +63,7 @@ def py4ps_version_check():
                                           "'pkg_resources', please install" \
                                           " the required package"
         else:
-            min_ver = '1.7.0'
+            min_ver = '1.8.0'
             curr_version = PyPowerStore.__version__
             unsupported_version_message = "PyPowerStore {0} is not supported " \
                                           "by this module. Minimum supported" \
@@ -203,3 +204,23 @@ def failure_codes(exception):
     if isinstance(exception, PowerStoreException):
         codes = dict({'error_code': exception.err_code, 'status_code': exception.status_code})
     return codes
+
+
+def validate_timestamp(expiration_timestamp):
+    """Validates whether the timestamp is valid"""
+    try:
+        datetime.strptime(expiration_timestamp,
+                          '%Y-%m-%dT%H:%M:%SZ')
+        return True
+    except ValueError:
+        return False
+
+
+'''
+Validate whether param is empty or not
+'''
+
+
+def is_param_empty(param):
+    if param is not None and (param.count(" ") > 0 or len(param.strip()) == 0):
+        return True

--- a/plugins/modules/certificate.py
+++ b/plugins/modules/certificate.py
@@ -262,7 +262,7 @@ IS_SUPPORTED_PY4PS_VERSION = py4ps_version['supported_version']
 VERSION_ERROR = py4ps_version['unsupported_version_message']
 
 # Application type
-APPLICATION_TYPE = 'Ansible/1.6.0'
+APPLICATION_TYPE = 'Ansible/1.7.0'
 
 
 class PowerStoreCertificate(object):

--- a/plugins/modules/cluster.py
+++ b/plugins/modules/cluster.py
@@ -12,17 +12,19 @@ module: cluster
 
 version_added: '1.3.0'
 
-short_description: Manage cluster related opeartions on PowerStore
+short_description: Manage cluster related operations on PowerStore
 
 description:
-- Managing cluster on PowerStore storage system includes getting details and
-  modifying cluster configuration parameters.
+- Managing cluster on PowerStore storage system includes creating cluster,
+  validating create cluster attributes, getting details and modifying cluster
+  configuration parameters.
 
 extends_documentation_fragment:
   - dellemc.powerstore.powerstore
 
 author:
 - P Srinivas Rao (@srinivas-rao5) <ansible.team@dell.com>
+- Bhavneet Sharma (@sharmb5) <ansible.team@dell.com>
 
 options:
   cluster_name:
@@ -69,6 +71,234 @@ options:
     - MTU for ethernet ports in the cluster.
     - The MTU can be set between 1500 to 9000.
     type: int
+  ignore_network_warnings:
+    description:
+    - Whether to ignore the network warning about unreachable external network.
+    type: bool
+    required: false
+  appliances:
+    description:
+    - Appliance configuration setting during cluster creation.
+    - This is mandatory for create cluster operation.
+    type: list
+    elements: dict
+    suboptions:
+      link_local_address:
+        description:
+        - The unique IPv4 address of the appliance and is set by zeroconf.
+        type: str
+        required: True
+      name:
+        description:
+        - Name of new appliance.
+        type: str
+      drive_failure_tolerance_level:
+        description:
+        - Specifies the possible drive failure tolerance levels.
+        type: str
+        choices: ['Single', 'Double']
+  dns_servers:
+    description:
+    - DNS server addresses in IPv4 format. At least one DNS server should be
+      provided.
+    - This is mandatory for create cluster operation.
+    type: list
+    elements: str
+  ntp_servers:
+    description:
+    - NTP server addresses in IPv4 or hostname format. At least one NTP server
+      should be provided.
+    - This is mandatory for create cluster operation.
+    type: list
+    elements: str
+  physical_switches:
+    description:
+    - Physical switch setting for a new cluster.
+    type: list
+    elements: dict
+    suboptions:
+      name:
+        description:
+        - Name of the physical switch.
+        type: str
+        required: True
+      purpose:
+        description:
+        - Specifies the purpose of the physical switch.
+        type: str
+        required: True
+        choices: ['Data_and_Management', 'Management_Only']
+      connections:
+        description:
+        - specifies the supported connection for the physical switch.
+        type: list
+        required: True
+        elements: dict
+        suboptions:
+          address:
+            description:
+            - Specifies the physical switch address in IPv4 or DNS hostname
+              format.
+            type: str
+            required: True
+          port:
+            description:
+            - Specifies the port used for connection to switch.
+            type: int
+          connect_method:
+            description:
+            - Specifies the connection method type for the physical Switch.
+            type: str
+            required: True
+            choices: ['SSH', 'SNMPv2c']
+          username:
+            description:
+            - Specifies username to connect a physical switch for SSH connection
+              method.
+            type: str
+          ssh_password:
+            description:
+            - Specifies SSH password to connect a physical switch.
+            type: str
+          snmp_community_string:
+            description:
+            - Specifies SNMPv2 community string, if SNMPv2 connect method is
+              selected.
+            type: str
+  networks:
+    description:
+    - Configuration of one or more network(s) based on network type.
+    - This is mandatory for create cluster operation.
+    type: list
+    elements: dict
+    suboptions:
+      type:
+        description:
+        - Specifies the type of the network.
+        type: str
+        required: True
+        choices: ['Management', 'Intra_Cluster_Management',
+          'Intra_Cluster_Data', 'Storage', 'VMotion', 'File_Mobility']
+      vlan_id:
+        description:
+        - The ID of the VLAN.
+        type: int
+      prefix_length:
+        description:
+        - Network prefix length.
+        type: int
+        required: True
+      gateway:
+        description:
+        - Network gateway in IPv4 format.
+        type: str
+      cluster_mgmt_address:
+        description:
+        - New cluster management IP address in IPv4 format.
+        type: str
+      storage_discovery_address:
+        description:
+        - New storage discovery IP address in IPv4 format.
+        - This can be specified only when configure the storage network type.
+        type: str
+      addresses:
+        description:
+        - IP addresses in IPv4 format.
+        type: list
+        elements: str
+        required: True
+      purposes:
+        description:
+        - Purpose of the network.
+        - Only applicable for storage network.
+        type: list
+        elements: str
+        choices: ['ISCSI', 'NVMe_TCP', 'File_Mobility']
+  vcenters:
+    description:
+    - Configure vCenter settings when creating cluster.
+    - Currently, for vcenters parameter API supports only single element.
+    - This is required when creating PowerStore X cluster and optional for
+      PowerStore T.
+    type: list
+    elements: dict
+    suboptions:
+      address:
+        description:
+        - IP address of vCenter in IPv4 or hostname format.
+        type: str
+        required: True
+      username:
+        description:
+        - User name to login to vCenter.
+        type: str
+        required: True
+      password:
+        description:
+        - Password to login to vCenter.
+        type: str
+        required: True
+      is_verify_server_cert:
+        description:
+        - Whether or not the connection will be secured with the vcenter SSL
+          certificate.
+        type: bool
+        required: True
+      data_center_name:
+        description:
+        - Name of the data center.
+        - This is used to join an existing datacenter in vcenter.
+        - This should be specified when creating PowerStore X cluster.
+        - Mutually exclusive with data_center_id.
+        type: str
+      data_center_id:
+        description:
+        - The VMWare ID of datacenter.
+        - This is used to join an existing datacenter in vcenter.
+        - This should be specified when creating PowerStore X cluster.
+        - Mutually exclusive with data_center_name.
+        type: str
+      esx_cluster_name:
+        description:
+        - Name of the ESXi cluster.
+        - This should be specified when creating PowerStore X cluster.
+        type: str
+      vasa_provider_credentials:
+        description:
+        - Storage system credentials for vCenter to use for communicating with
+          the storage system using VASA.
+        type: dict
+        required: True
+        suboptions:
+          username:
+            description:
+            - Username of the local user account which will be used by vSphere
+              to register VASA provider.
+            type: str
+            required: True
+          password:
+            description:
+            - Password of the local user account which will be used by vSphere
+              to register VASA provider.
+            type: str
+            required: True
+  is_http_redirect_enabled:
+    description:
+    - Whether to redirect the HTTP requests to HTTPS.
+    type: bool
+  validate_create:
+    description:
+    - Whether to perform create cluster validate call.
+    default: True
+    type: bool
+  wait_for_completion:
+    description:
+    - Flag to indicate if the operation should be run synchronously or
+      asynchronously.
+    - True signifies synchronous execution. By default, create cluster
+      operation will run asynchronously.
+    default: False
+    type: bool
   state:
     description:
     - Define whether the cluster should exist or not.
@@ -79,8 +309,18 @@ options:
     choices: ['absent', 'present']
 
 notes:
-- Creation and deletion of cluster is not supported by ansible modules.
+- Deletion of a cluster is not supported by ansible module.
 - The check_mode is not supported.
+- Before performing create operation, the default password for admin user and
+  service user should be changed.
+- For management type network during cluster creation,
+  storage_discovery_address and purposes should not be passed.
+- The vcenters parameter is mandatory for PowerStore X cluster creation.
+- Minimum 3 and 5 addresses are required for management network for PowerStore
+  T and X model respectively.
+- The File_Mobility purpose is supported only in FootHills Prime and above.
+- Parameter is_http_redirect_enabled is supported only in PowerStore FootHills
+  Prime and above.
 '''
 
 EXAMPLES = r'''
@@ -106,6 +346,101 @@ EXAMPLES = r'''
     chap_mode: "Disabled"
     new_name: "new_RT-D1320"
     state: "present"
+
+- name: Validate create cluster
+  dellemc.powerstore.cluster:
+    array_ip: "{{array_ip}}"
+    verifycert: "{{verifycert}}"
+    user: "{{user}}"
+    password: "{{password}}"
+    cluster_name: "RT-D1320"
+    ignore_network_warnings: True
+    appliances:
+      - link_local_address: "1.2.x.x"
+        name: "Ansible_cluster"
+        derive_failure_tolerance_level: "Double"
+    dns_servers:
+      - "1.1.x.x"
+    ntp_servers:
+      - "1.3.x.x"
+    networks:
+      - type: "Management"
+        vlan_id: 0
+        prefix_length: 24
+        gateway: "1.x.x.x"
+        cluster_mgmt_address: "1.x.x.x"
+        addresses:
+          - "2.x.x.x"
+          - "3.x.x.x"
+      - type: "Storage"
+        vlan_id: 0
+        prefix_length: 42
+        gateway: "1.x.x.x"
+        storage_discovery_address: "1.x.x.x"
+        addresses:
+          - "2.x.x.x"
+          - "3.x.x.x"
+        purpose:
+          - "ISCSI"
+    is_http_redirect_enabled: True
+    validate_create: True
+    state: "present"
+
+- name: Create cluster
+  dellemc.powerstore.cluster:
+    array_ip: "{{array_ip}}"
+    verifycert: "{{verifycert}}"
+    user: "{{user}}"
+    password: "{{password}}"
+    cluster_name: "RT-D1320"
+    ignore_network_warnings: True
+    appliances:
+      - link_local_address: "1.2.x.x"
+        name: "Ansible_cluster"
+        derive_failure_tolerance_level: "Double"
+    dns_servers:
+      - "1.1.x.x"
+    ntp_servers:
+      - "1.3.x.x"
+    physical_switch:
+      - name: "Ansible_switch"
+        purpose: "Management_Only"
+        connections:
+          - address: "1.x.x.x"
+            port: 20
+            connect_method: "SSH"
+            username: "user"
+            ssh_password: "password"
+    networks:
+      - type: "Management"
+        vlan_id: 0
+        prefix_length: 24
+        gateway: "1.x.x.x"
+        cluster_mgmt_address: "1.x.x.x"
+        addresses:
+          - "2.x.x.x"
+          - "3.x.x.x"
+      - type: "Storage"
+        vlan_id: 0
+        prefix_length: 42
+        gateway: "1.x.x.x"
+        storage_discovery_address: "1.x.x.x"
+        addresses:
+          - "2.x.x.x"
+          - "3.x.x.x"
+        purpose:
+          - "ISCSI"
+    vcenters:
+      - address: "1.x.x.x"
+        username: "user"
+        password: "password"
+        is_verify_server_cert: True
+        vasa_provider_credentials:
+          username: "user"
+          password: "password"
+    is_http_redirect_enabled: True
+    wait_for_completion: False
+    state: "present"
 '''
 
 RETURN = r'''
@@ -114,6 +449,44 @@ changed:
     returned: always
     type: bool
     sample: "true"
+
+job_details:
+    description: The job details.
+    type: complex
+    returned: When asynchronous task is performed.
+    contains:
+        id:
+            description: The ID of the job.
+            type: str
+    sample: {
+        "description_l10n": "Create Cluster.",
+        "end_time": "2022-01-06T07:39:05.846+00:00",
+        "estimated_completion_time": null,
+        "id": "be0d099c-a6cf-44e8-88d7-9be80ccae369",
+        "parent_id": null,
+        "phase": "Completed",
+        "phase_l10n": "Completed",
+        "progress_percentage": 100,
+        "resource_action": "create",
+        "resource_action_l10n": "create",
+        "resource_id": "0",
+        "resource_name": null,
+        "resource_type": "cluster",
+        "resource_type_l10n": "cluster",
+        "response_body": {
+            "id": 0,
+            "response_type": "job_create_response"
+        },
+        "response_status": null,
+        "response_status_l10n": null,
+        "root_id": "be0d099c-a6cf-44e8-88d7-9be80ccae369",
+        "start_time": "2022-01-06T07:39:05.47+00:00",
+        "state": "COMPLETED",
+        "state_l10n": "Completed",
+        "step_order": 23792565,
+        "user": "admin"
+    }
+
 cluster_details:
     description: The cluster details.
     type: complex
@@ -242,6 +615,7 @@ cluster_details:
 from ansible_collections.dellemc.powerstore.plugins.module_utils.storage.dell\
     import utils
 from ansible.module_utils.basic import AnsibleModule
+import copy
 
 LOG = utils.get_logger('cluster')
 
@@ -254,7 +628,7 @@ IS_SUPPORTED_PY4PS_VERSION = py4ps_version['supported_version']
 VERSION_ERROR = py4ps_version['unsupported_version_message']
 
 # Application type
-APPLICATION_TYPE = 'Ansible/1.6.0'
+APPLICATION_TYPE = 'Ansible/1.7.0'
 
 
 class PowerStoreCluster(object):
@@ -271,11 +645,14 @@ class PowerStoreCluster(object):
             ['cluster_name', 'cluster_id'],
             ['appliance_name', 'appliance_id']
         ]
+        required_together = [['appliances', 'networks', 'dns_servers',
+                              'ntp_servers']]
         required_one_of = [['cluster_name', 'cluster_id']]
         self.module = AnsibleModule(
             argument_spec=self.module_params,
             supports_check_mode=False,
             mutually_exclusive=mut_ex_args,
+            required_together=required_together,
             required_one_of=required_one_of
         )
 
@@ -299,6 +676,7 @@ class PowerStoreCluster(object):
         self.conn = utils.get_powerstore_connection(
             self.module.params, application_type=APPLICATION_TYPE)
         self.configuration = self.conn.config_mgmt
+        self.provisioning = self.conn.provisioning
         msg = 'Got Py4Ps instance for configuring cluster on' \
               ' PowerStore {0}'.format(self.conn)
         LOG.info(msg)
@@ -447,6 +825,267 @@ class PowerStoreCluster(object):
             LOG.error(msg)
             self.module.fail_json(msg=msg, **utils.failure_codes(e))
 
+    def prepare_network_payload(self, networks):
+        """
+        To remove storage_discovery_address and purposes key form management type
+        network
+        :param networks: List of dict of networks for cluster
+        """
+        for net_dict in networks:
+            if net_dict['type'] == 'Management' and \
+                    ('storage_discovery_address' in net_dict
+                     or 'purposes' in net_dict):
+                if net_dict['storage_discovery_address'] is not None or \
+                        net_dict['purposes'] is not None:
+                    error_msg = "storage_discovery_address and purposes " \
+                                "should not be provided for management " \
+                                "type network."
+                    self.module.fail_json(msg=error_msg)
+                else:
+                    del net_dict['storage_discovery_address']
+                    del net_dict['purposes']
+                    break
+            elif net_dict['type'] == 'Storage' and \
+                    'cluster_mgmt_address' in net_dict:
+                del net_dict['cluster_mgmt_address']
+                break
+            elif net_dict['type'] == 'VMotion' and \
+                    ('cluster_mgmt_address' in net_dict or
+                     'storage_discovery_address' in net_dict or
+                     'purpose' in net_dict):
+                del net_dict['cluster_mgmt_address']
+                del net_dict['storage_discovery_address']
+                del net_dict['purposes']
+                break
+
+    def create_cluster_validate(self, cluster_name):
+        """Create cluster validation operation"""
+
+        ignore_network_warnings = self.module.params['ignore_network_warnings']
+        dns_servers = self.module.params['dns_servers']
+        ntp_servers = self.module.params['ntp_servers']
+        is_http_redirect_enabled = self.module.params['is_http_redirect_enabled']
+
+        clusters = dict()
+        clusters['name'] = cluster_name
+        clusters['ignore_network_warnings'] = ignore_network_warnings
+        appliances = copy.deepcopy(self.module.params['appliances'])
+        physical_switches = copy.deepcopy(self.module.params['physical_switches'])
+        networks = copy.deepcopy(self.module.params['networks'])
+        vcenters = self.module.params['vcenters']
+
+        if networks is not None:
+            self.prepare_network_payload(networks)
+
+        try:
+            # cluster create validate operation
+            LOG.info("Validating the new cluster configurations.")
+            resp = self.configuration.cluster_create_validate(
+                cluster=clusters, appliances=appliances,
+                dns_servers=dns_servers, ntp_servers=ntp_servers,
+                networks=networks,
+                is_http_redirect_enabled=is_http_redirect_enabled,
+                physical_switches=physical_switches, vcenters=vcenters)
+            LOG.info("response of validate create %s ", str(resp))
+            return True, resp
+        except Exception as e:
+            msg = "Validation of create cluster {0} failed with " \
+                  "{1}".format(cluster_name, str(e))
+            LOG.error(msg)
+            self.module.fail_json(msg=msg, **utils.failure_codes(e))
+
+    def create_cluster(self, cluster_name, wait_for_completion):
+        """ Create the new cluster"""
+
+        ignore_network_warnings = self.module.params['ignore_network_warnings']
+        dns_servers = self.module.params['dns_servers']
+        ntp_servers = self.module.params['ntp_servers']
+        is_http_redirect_enabled = self.module.params['is_http_redirect_enabled']
+
+        clusters = dict()
+        clusters['name'] = cluster_name
+        clusters['ignore_network_warnings'] = ignore_network_warnings
+        appliances = copy.deepcopy(self.module.params['appliances'])
+        physical_switches = copy.deepcopy(
+            self.module.params['physical_switches'])
+        networks = copy.deepcopy(self.module.params['networks'])
+        vcenters = self.module.params['vcenters']
+
+        if networks is not None:
+            self.prepare_network_payload(networks)
+
+        if wait_for_completion:
+            is_async = False
+        else:
+            is_async = True
+
+        try:
+            # cluster create operation
+            LOG.info("Creating new cluster configurations.")
+            job_dict = self.configuration.cluster_create(
+                cluster=clusters, appliances=appliances,
+                dns_servers=dns_servers, ntp_servers=ntp_servers,
+                networks=networks,
+                is_http_redirect_enabled=is_http_redirect_enabled,
+                physical_switches=physical_switches, vcenters=vcenters,
+                is_async=is_async)
+            LOG.info("response is: %s", str(job_dict))
+            return True, job_dict
+        except Exception as e:
+            err_msg = "Cluster {0} creation failed with " \
+                      "{1}".format(cluster_name, str(e))
+            LOG.error(err_msg)
+            self.module.fail_json(msg=err_msg, **utils.failure_codes(e))
+
+    def validate_vcenters_params(self):
+        """Validate vCenters parameters"""
+
+        vcenters = self.module.params['vcenters']
+
+        if vcenters:
+            for vcenter in vcenters:
+                if 'address' in vcenter and vcenter['address'] is not None and \
+                        len(vcenter['address'].strip()) == 0:
+                    err_msg = "Provide valid address for new " \
+                              "vcenter configuration."
+                    self.module.fail_json(msg=err_msg)
+                if 'data_center_name' in vcenter and \
+                        'data_center_id' in vcenter and \
+                        vcenter['data_center_name'] is not None and \
+                        vcenter['data_center_id'] is not None:
+                    err_msg = "parameters are mutually exclusive: " \
+                              "data_center_name|data_center_id"
+                    self.module.fail_json(msg=err_msg)
+
+    def validate_addresses_params(self, net_dict):
+        """
+        Validate the addresses related params
+        """
+        param_list = ['cluster_mgmt_address', 'storage_discovery_address']
+        for param in param_list:
+            if param in net_dict and net_dict[param] is not None and \
+                    (len(net_dict[param].strip()) == 0 or
+                     " " in net_dict[param]):
+                err_msg = "Provide valid {0}.".format(param)
+                self.module.fail_json(msg=err_msg)
+
+    def validate_networks_params(self):
+        """Validate Networks parameters"""
+
+        networks = self.module.params['networks']
+        if networks:
+            for net_dict in networks:
+                if 'addresses' in net_dict and \
+                        net_dict['type'] == 'Management' and \
+                        len(net_dict['addresses']) < 3:
+                    err_msg = "For Management network, minimum 3 addresses " \
+                              "for PowerStore T and minimum 5 addresses for" \
+                              " PowerStore X should be provided."
+                    self.module.fail_json(msg=err_msg)
+                if net_dict['type'] == 'Management' and \
+                        ('cluster_mgmt_address' not in net_dict or
+                         net_dict['cluster_mgmt_address'] is None):
+                    err_msg = "The cluster_mgmt_address should be provided" \
+                              " for Management type network."
+                    self.module.fail_json(msg=err_msg)
+                self.validate_addresses_params(net_dict)
+
+    def validate_connections_dict(self, connections):
+        """Validate connections dict parameters"""
+
+        for connect_dict in connections:
+            if 'address' in connect_dict and connect_dict['address'] is not None and \
+                    len(connect_dict['address'].strip()) == 0:
+                error_msg = "The address should be provided" \
+                            " in connections."
+                self.module.fail_json(msg=error_msg)
+            if connect_dict['connect_method'] == "SSH" and \
+                    (connect_dict['username'] is None or
+                     connect_dict['ssh_password'] is None):
+                error_msg = "username/ssh_password should be provided with " \
+                            "SSH connect_method"
+                self.module.fail_json(msg=error_msg)
+            if connect_dict['connect_method'] == "SNMPv2c" and \
+                    not connect_dict['snmp_community_string']:
+                error_msg = "snmp_community_string should be provided with " \
+                            "SNMPv2c connect_method"
+                self.module.fail_json(msg=error_msg)
+
+    def validate_physical_switch_params(self):
+        """ Validate physical switch parameters"""
+
+        physical_switches = self.module.params['physical_switches']
+        if physical_switches:
+            for switch_list in physical_switches:
+                if 'name' in switch_list and \
+                        utils.is_param_empty(switch_list['name']):
+                    err_msg = "Provide valid physical switch name."
+                    self.module.fail_json(msg=err_msg)
+                connections = switch_list['connections']
+                if len(connections) == 0:
+                    error_msg = "connections details should be present in " \
+                                "physical_switches."
+                    self.module.fail_json(msg=error_msg)
+                self.validate_connections_dict(connections)
+
+    def validate_ntp_or_dns(self):
+        """validate the NTP and DNS server addresses"""
+
+        dns_servers = self.module.params['dns_servers']
+        ntp_servers = self.module.params['ntp_servers']
+
+        if dns_servers is not None and len(dns_servers) > 3:
+            err_msg = "Maximum three address should be provided for" \
+                      " dns_servers."
+            self.module.fail_json(msg=err_msg)
+
+        if ntp_servers is not None and len(ntp_servers) > 3:
+            err_msg = "Maximum three address should be provided for" \
+                      " ntp_servers."
+            self.module.fail_json(msg=err_msg)
+
+    def validate_create_parameters(self):
+        """Validate the input parameters"""
+
+        # Check for space
+        if utils.is_param_empty(self.module.params['cluster_name']):
+            error_msg = "Provide valid {0}".format('cluster_name')
+            self.module.fail_json(msg=error_msg)
+
+        self.validate_ntp_or_dns()
+
+        appliances = self.module.params['appliances']
+        if appliances:
+            for app_dict in appliances:
+                if 'link_local_address' in app_dict and \
+                        (len(app_dict['link_local_address'].strip()) == 0 or
+                         " " in app_dict['link_local_address']):
+                    error_msg = "Provide valid link_local_address for " \
+                                "an appliance."
+                    self.module.fail_json(msg=error_msg)
+
+                if 'name' in app_dict and \
+                        utils.is_param_empty(app_dict['name']):
+                    error_msg = "Provide valid name of an appliance."
+                    self.module.fail_json(msg=error_msg)
+        self.validate_physical_switch_params()
+        self.validate_networks_params()
+        self.validate_vcenters_params()
+
+    def get_cluster_list(self):
+        """
+        Getting list of cluster to filter create and create validate operation
+        """
+        try:
+            LOG.info("Getting list of clusters.")
+            clusters = self.provisioning.get_cluster_list()
+            return clusters
+        except Exception as e:
+            error_msg = "Getting list of clusters failed with error: " \
+                        "{0}".format(str(e))
+            LOG.error(error_msg)
+            self.module.fail_json(msg=error_msg, **utils.failure_codes(e))
+
     def perform_module_operation(self):
         """
         Perform different actions on cluster module based on parameters
@@ -463,8 +1102,18 @@ class PowerStoreCluster(object):
         state = self.module.params['state']
         appliance_name = self.module.params['appliance_name']
         appliance_id = self.module.params['appliance_id']
+        validate_create = self.module.params['validate_create']
+        wait_for_completion = self.module.params['wait_for_completion']
 
         changed = False
+        create_changed = False
+        cluster_details = {}
+        validate_resp = {}
+        job_dict = {}
+
+        clusters = self.get_cluster_list()
+        self.validate_create_parameters()
+
         # if is_ssh_enabled is passed and appliance name/id is not passed.
         if not (appliance_id or appliance_name) and is_ssh_enabled is not None:
             self.module.fail_json(
@@ -487,18 +1136,24 @@ class PowerStoreCluster(object):
                 self.module.fail_json(
                     msg="Unable to fetch the appliance details. Please provide"
                         " a valid appliance_name.")
-            service_config_id = appliance_details['id']
-            appliance_id = appliance_details['id']
+            elif appliance_details:
+                service_config_id = appliance_details['id']
+                appliance_id = appliance_details['id']
 
-        cluster_details = self.get_cluster_details(cluster_name, cluster_id)
+        if clusters is not None and clusters[0]['name'] is not None:
+            cluster_details = self.get_cluster_details(cluster_name, cluster_id)
         if cluster_details and cluster_name:
             cluster_id = cluster_details['id']
 
+        # Validate create cluster operation
         if state == 'present' and not cluster_details:
-            self.module.fail_json(
-                msg="Creation of cluster is currently not supported by the "
-                    "module. Please enter the cluster_name/cluster_id of the "
-                    "existing cluster.")
+            if validate_create:
+                changed, validate_resp = self.\
+                    create_cluster_validate(cluster_name)
+            else:
+                # Create cluster operation
+                create_changed, job_dict = self.\
+                    create_cluster(cluster_name, wait_for_completion)
 
         if state == 'absent' and cluster_details:
             self.module.fail_json(
@@ -506,7 +1161,8 @@ class PowerStoreCluster(object):
                     "currently not supported by the module.")
 
         # cluster details with all the parameters needed for modify
-        cluster_details = self.show_cluster_details(cluster_id, appliance_id)
+        if clusters is not None and clusters[0]['name'] is not None:
+            cluster_details = self.show_cluster_details(cluster_id, appliance_id)
 
         if state == 'present' and cluster_details:
             update_params_dict = modify_payload(
@@ -517,9 +1173,19 @@ class PowerStoreCluster(object):
                                     update_params_dict)
                 changed = True
 
-        cluster_details = self.show_cluster_details(cluster_id, appliance_id)
-        self.result["changed"] = changed
-        self.result["cluster_details"] = cluster_details
+        if state == 'present' and not wait_for_completion and create_changed \
+                and not validate_create:
+            self.result["changed"] = create_changed
+            self.result["job_details"] = job_dict
+        elif state == 'present' and changed and validate_create and \
+                clusters[0]['name'] is None:
+            self.result["changed"] = changed
+            self.result["cluster_details"] = {}
+            self.result['validate_response'] = validate_resp
+        else:
+            self.result["changed"] = changed
+            self.result["cluster_details"] = self.\
+                show_cluster_details(cluster_id, appliance_id)
         self.module.exit_json(**self.result)
 
 
@@ -567,6 +1233,68 @@ def get_powerstore_cluster_parameters():
         chap_mode=dict(choices=['Disabled', 'Single', 'Mutual']),
         is_ssh_enabled=dict(type='bool'), new_name=dict(),
         physical_mtu=dict(type='int'),
+        ignore_network_warnings=dict(type='bool'),
+        appliances=dict(
+            type='list', elements='dict',
+            options=dict(
+                link_local_address=dict(
+                    type='str', required=True),
+                name=dict(type='str'),
+                drive_failure_tolerance_level=dict(
+                    type='str', choices=['Single', 'Double']))),
+        dns_servers=dict(type='list', elements='str'),
+        ntp_servers=dict(type='list', elements='str'),
+        physical_switches=dict(
+            type='list', elements='dict', options=dict(
+                name=dict(type='str', required=True), purpose=dict(
+                    type='str', required=True,
+                    choices=['Data_and_Management', 'Management_Only']),
+                connections=dict(
+                    type='list', elements='dict', required=True, options=dict(
+                        address=dict(type='str', required=True),
+                        port=dict(type='int'),
+                        connect_method=dict(
+                            type='str', choices=['SSH', 'SNMPv2c'],
+                            required=True), username=dict(type='str'),
+                        ssh_password=dict(type='str', no_log=True),
+                        snmp_community_string=dict(type='str', no_log=True))))),
+        networks=dict(type='list', elements='dict',
+                      options=dict(
+                          type=dict(
+                              type='str', required=True,
+                              choices=['Management',
+                                       'Intra_Cluster_Management',
+                                       'Intra_Cluster_Data', 'Storage',
+                                       'VMotion', 'File_Mobility']),
+                          vlan_id=dict(type='int'),
+                          prefix_length=dict(type='int', required=True),
+                          gateway=dict(type='str'),
+                          cluster_mgmt_address=dict(type='str'),
+                          storage_discovery_address=dict(type='str'),
+                          addresses=dict(type='list', elements='str',
+                                         required=True),
+                          purposes=dict(
+                              type='list', elements='str',
+                              choices=['ISCSI', 'NVMe_TCP',
+                                       'File_Mobility']))),
+        vcenters=dict(
+            type='list', elements='dict',
+            options=dict(
+                address=dict(type='str', required=True),
+                username=dict(type='str', required=True),
+                password=dict(type='str', required=True, no_log=True),
+                is_verify_server_cert=dict(type='bool', required=True),
+                data_center_name=dict(type='str'),
+                data_center_id=dict(type='str'),
+                esx_cluster_name=dict(type='str'),
+                vasa_provider_credentials=dict(
+                    type='dict', required=True, options=dict(
+                        username=dict(type='str', required=True),
+                        password=dict(type='str', required=True,
+                                      no_log=True))))),
+        is_http_redirect_enabled=dict(type='bool'),
+        validate_create=dict(type='bool', default=True),
+        wait_for_completion=dict(type='bool', default=False),
         state=dict(required=True, choices=['present', 'absent'])
     )
 

--- a/plugins/modules/dns.py
+++ b/plugins/modules/dns.py
@@ -129,7 +129,7 @@ IS_SUPPORTED_PY4PS_VERSION = py4ps_version['supported_version']
 VERSION_ERROR = py4ps_version['unsupported_version_message']
 
 # Application type
-APPLICATION_TYPE = 'Ansible/1.6.0'
+APPLICATION_TYPE = 'Ansible/1.7.0'
 
 
 class PowerstoreDns(object):

--- a/plugins/modules/email.py
+++ b/plugins/modules/email.py
@@ -213,7 +213,7 @@ IS_SUPPORTED_PY4PS_VERSION = py4ps_version['supported_version']
 VERSION_ERROR = py4ps_version['unsupported_version_message']
 
 # Application type
-APPLICATION_TYPE = 'Ansible/1.6.0'
+APPLICATION_TYPE = 'Ansible/1.7.0'
 
 
 class PowerstoreEmail(object):

--- a/plugins/modules/filesystem.py
+++ b/plugins/modules/filesystem.py
@@ -370,7 +370,7 @@ IS_SUPPORTED_PY4PS_VERSION = py4ps_version['supported_version']
 VERSION_ERROR = py4ps_version['unsupported_version_message']
 
 # Application type
-APPLICATION_TYPE = 'Ansible/1.6.0'
+APPLICATION_TYPE = 'Ansible/1.7.0'
 
 
 class PowerStoreFileSystem(object):

--- a/plugins/modules/filesystem_snapshot.py
+++ b/plugins/modules/filesystem_snapshot.py
@@ -253,7 +253,7 @@ IS_SUPPORTED_PY4PS_VERSION = py4ps_version['supported_version']
 VERSION_ERROR = py4ps_version['unsupported_version_message']
 
 # Application type
-APPLICATION_TYPE = 'Ansible/1.6.0'
+APPLICATION_TYPE = 'Ansible/1.7.0'
 
 
 class PowerStoreFilesystemSnapshot(object):

--- a/plugins/modules/host.py
+++ b/plugins/modules/host.py
@@ -401,7 +401,7 @@ IS_SUPPORTED_PY4PS_VERSION = py4ps_version['supported_version']
 VERSION_ERROR = py4ps_version['unsupported_version_message']
 
 # Application type
-APPLICATION_TYPE = 'Ansible/1.6.0'
+APPLICATION_TYPE = 'Ansible/1.7.0'
 
 # DO NOT CHANGE BELOW PORT_TYPES SEQUENCE AS ITS USED IN SCRIPT USING INDEX
 PORT_TYPES = ["iSCSI", "FC", "NVMe"]

--- a/plugins/modules/hostgroup.py
+++ b/plugins/modules/hostgroup.py
@@ -230,7 +230,7 @@ IS_SUPPORTED_PY4PS_VERSION = py4ps_version['supported_version']
 VERSION_ERROR = py4ps_version['unsupported_version_message']
 
 # Application type
-APPLICATION_TYPE = 'Ansible/1.6.0'
+APPLICATION_TYPE = 'Ansible/1.7.0'
 
 
 class PowerStoreHostgroup(object):

--- a/plugins/modules/info.py
+++ b/plugins/modules/info.py
@@ -1003,7 +1003,7 @@ IS_SUPPORTED_PY4PS_VERSION = py4ps_version['supported_version']
 VERSION_ERROR = py4ps_version['unsupported_version_message']
 
 # Application type
-APPLICATION_TYPE = 'Ansible/1.6.0'
+APPLICATION_TYPE = 'Ansible/1.7.0'
 
 
 class PowerstoreInfo(object):

--- a/plugins/modules/job.py
+++ b/plugins/modules/job.py
@@ -174,7 +174,7 @@ IS_SUPPORTED_PY4PS_VERSION = py4ps_version['supported_version']
 VERSION_ERROR = py4ps_version['unsupported_version_message']
 
 # Application type
-APPLICATION_TYPE = 'Ansible/1.6.0'
+APPLICATION_TYPE = 'Ansible/1.7.0'
 
 
 class PowerStoreJob(object):

--- a/plugins/modules/ldap_account.py
+++ b/plugins/modules/ldap_account.py
@@ -173,7 +173,7 @@ IS_SUPPORTED_PY4PS_VERSION = py4ps_version['supported_version']
 VERSION_ERROR = py4ps_version['unsupported_version_message']
 
 # Application type
-APPLICATION_TYPE = 'Ansible/1.6.0'
+APPLICATION_TYPE = 'Ansible/1.7.0'
 
 
 class PowerStoreLDAPAccount(object):

--- a/plugins/modules/ldap_domain.py
+++ b/plugins/modules/ldap_domain.py
@@ -354,7 +354,7 @@ IS_SUPPORTED_PY4PS_VERSION = py4ps_version['supported_version']
 VERSION_ERROR = py4ps_version['unsupported_version_message']
 
 # Application type
-APPLICATION_TYPE = 'Ansible/1.6.0'
+APPLICATION_TYPE = 'Ansible/1.7.0'
 
 
 class PowerStoreLDAPDomain(object):

--- a/plugins/modules/local_user.py
+++ b/plugins/modules/local_user.py
@@ -185,7 +185,7 @@ IS_SUPPORTED_PY4PS_VERSION = py4ps_version['supported_version']
 VERSION_ERROR = py4ps_version['unsupported_version_message']
 
 # Application type
-APPLICATION_TYPE = 'Ansible/1.6.0'
+APPLICATION_TYPE = 'Ansible/1.7.0'
 
 
 class PowerStoreLocalUser(object):

--- a/plugins/modules/network.py
+++ b/plugins/modules/network.py
@@ -498,7 +498,7 @@ IS_SUPPORTED_PY4PS_VERSION = py4ps_version['supported_version']
 VERSION_ERROR = py4ps_version['unsupported_version_message']
 
 # Application type
-APPLICATION_TYPE = 'Ansible/1.6.0'
+APPLICATION_TYPE = 'Ansible/1.7.0'
 
 
 class PowerStoreNetwork(object):

--- a/plugins/modules/ntp.py
+++ b/plugins/modules/ntp.py
@@ -130,7 +130,7 @@ IS_SUPPORTED_PY4PS_VERSION = py4ps_version['supported_version']
 VERSION_ERROR = py4ps_version['unsupported_version_message']
 
 # Application type
-APPLICATION_TYPE = 'Ansible/1.6.0'
+APPLICATION_TYPE = 'Ansible/1.7.0'
 
 
 class PowerstoreNtp(object):

--- a/plugins/modules/protectionpolicy.py
+++ b/plugins/modules/protectionpolicy.py
@@ -246,7 +246,7 @@ IS_SUPPORTED_PY4PS_VERSION = py4ps_version['supported_version']
 VERSION_ERROR = py4ps_version['unsupported_version_message']
 
 # Application type
-APPLICATION_TYPE = 'Ansible/1.6.0'
+APPLICATION_TYPE = 'Ansible/1.7.0'
 
 
 class PowerstoreProtectionpolicy(object):

--- a/plugins/modules/quota.py
+++ b/plugins/modules/quota.py
@@ -364,7 +364,7 @@ IS_SUPPORTED_PY4PS_VERSION = py4ps_version['supported_version']
 VERSION_ERROR = py4ps_version['unsupported_version_message']
 
 # Application type
-APPLICATION_TYPE = 'Ansible/1.6.0'
+APPLICATION_TYPE = 'Ansible/1.7.0'
 
 
 class PowerStoreQuota(object):

--- a/plugins/modules/remote_support.py
+++ b/plugins/modules/remote_support.py
@@ -371,7 +371,7 @@ IS_SUPPORTED_PY4PS_VERSION = py4ps_version['supported_version']
 VERSION_ERROR = py4ps_version['unsupported_version_message']
 
 # Application type
-APPLICATION_TYPE = 'Ansible/1.6.0'
+APPLICATION_TYPE = 'Ansible/1.7.0'
 
 
 class PowerstoreRemoteSupport(object):

--- a/plugins/modules/remote_support_contact.py
+++ b/plugins/modules/remote_support_contact.py
@@ -141,7 +141,7 @@ IS_SUPPORTED_PY4PS_VERSION = py4ps_version['supported_version']
 VERSION_ERROR = py4ps_version['unsupported_version_message']
 
 # Application type
-APPLICATION_TYPE = 'Ansible/1.6.0'
+APPLICATION_TYPE = 'Ansible/1.7.0'
 
 
 class PowerstoreRemoteSupportContact(object):

--- a/plugins/modules/remotesystem.py
+++ b/plugins/modules/remotesystem.py
@@ -318,7 +318,7 @@ IS_SUPPORTED_PY4PS_VERSION = py4ps_version['supported_version']
 VERSION_ERROR = py4ps_version['unsupported_version_message']
 
 # Application type
-APPLICATION_TYPE = 'Ansible/1.6.0'
+APPLICATION_TYPE = 'Ansible/1.7.0'
 
 
 class PowerstoreRemoteSystem(object):

--- a/plugins/modules/replicationrule.py
+++ b/plugins/modules/replicationrule.py
@@ -201,7 +201,7 @@ IS_SUPPORTED_PY4PS_VERSION = py4ps_version['supported_version']
 VERSION_ERROR = py4ps_version['unsupported_version_message']
 
 # Application type
-APPLICATION_TYPE = 'Ansible/1.6.0'
+APPLICATION_TYPE = 'Ansible/1.7.0'
 
 
 class PowerstoreReplicationRule(object):

--- a/plugins/modules/role.py
+++ b/plugins/modules/role.py
@@ -113,7 +113,7 @@ IS_SUPPORTED_PY4PS_VERSION = py4ps_version['supported_version']
 VERSION_ERROR = py4ps_version['unsupported_version_message']
 
 # Application type
-APPLICATION_TYPE = 'Ansible/1.6.0'
+APPLICATION_TYPE = 'Ansible/1.7.0'
 
 
 class PowerStoreRole(object):

--- a/plugins/modules/security_config.py
+++ b/plugins/modules/security_config.py
@@ -116,7 +116,7 @@ IS_SUPPORTED_PY4PS_VERSION = py4ps_version['supported_version']
 VERSION_ERROR = py4ps_version['unsupported_version_message']
 
 # Application type
-APPLICATION_TYPE = 'Ansible/1.6.0'
+APPLICATION_TYPE = 'Ansible/1.7.0'
 
 
 class PowerStoreSecurityConfig(object):

--- a/plugins/modules/smbshare.py
+++ b/plugins/modules/smbshare.py
@@ -311,7 +311,7 @@ IS_SUPPORTED_PY4PS_VERSION = py4ps_version['supported_version']
 VERSION_ERROR = py4ps_version['unsupported_version_message']
 
 # Application type
-APPLICATION_TYPE = 'Ansible/1.6.0'
+APPLICATION_TYPE = 'Ansible/1.7.0'
 
 
 class PowerStoreSMBShare(object):

--- a/plugins/modules/smtp_config.py
+++ b/plugins/modules/smtp_config.py
@@ -143,7 +143,7 @@ IS_SUPPORTED_PY4PS_VERSION = py4ps_version['supported_version']
 VERSION_ERROR = py4ps_version['unsupported_version_message']
 
 # Application type
-APPLICATION_TYPE = 'Ansible/1.6.0'
+APPLICATION_TYPE = 'Ansible/1.7.0'
 
 
 class PowerstoreSmtpConfig(object):

--- a/plugins/modules/snapshot.py
+++ b/plugins/modules/snapshot.py
@@ -344,7 +344,7 @@ IS_SUPPORTED_PY4PS_VERSION = py4ps_version['supported_version']
 VERSION_ERROR = py4ps_version['unsupported_version_message']
 
 # Application type
-APPLICATION_TYPE = 'Ansible/1.6.0'
+APPLICATION_TYPE = 'Ansible/1.7.0'
 
 
 class PowerStoreSnapshot(object):

--- a/plugins/modules/snapshotrule.py
+++ b/plugins/modules/snapshotrule.py
@@ -258,7 +258,7 @@ IS_SUPPORTED_PY4PS_VERSION = py4ps_version['supported_version']
 VERSION_ERROR = py4ps_version['unsupported_version_message']
 
 # Application type
-APPLICATION_TYPE = 'Ansible/1.6.0'
+APPLICATION_TYPE = 'Ansible/1.7.0'
 
 
 class PowerstoreSnapshotrule(object):

--- a/plugins/modules/volume.py
+++ b/plugins/modules/volume.py
@@ -443,7 +443,7 @@ IS_SUPPORTED_PY4PS_VERSION = py4ps_version['supported_version']
 VERSION_ERROR = py4ps_version['unsupported_version_message']
 
 # Application type
-APPLICATION_TYPE = 'Ansible/1.6.0'
+APPLICATION_TYPE = 'Ansible/1.7.0'
 
 
 class PowerStoreVolume(object):

--- a/tests/unit/plugins/module_utils/mock_cluster_api.py
+++ b/tests/unit/plugins/module_utils/mock_cluster_api.py
@@ -13,6 +13,47 @@ class MockClusterApi:
     MODULE_PATH = 'ansible_collections.dellemc.powerstore.plugins.modules.cluster.PowerStoreCluster'
     MODULE_UTILS_PATH = 'ansible_collections.dellemc.powerstore.plugins.module_utils.storage.dell.utils'
 
+    address_1 = "1.xx.xx.xx"
+    invalid_address_1 = "1.x x.x x.xx"
+    cluster_name = "test-cluster"
+    invalid_name = ' '
+
+    NET_DICT = {
+        'type': 'Storage',
+        'vlan_id': 0,
+        'prefix_length': 21,
+        'gateway': address_1,
+        'storage_discovery_address': invalid_address_1,
+        'addresses': [address_1]
+    }
+
+    MODIFIED_PARAMS = {
+        'cluster_name': cluster_name,
+        'ignore_network_warnings': True,
+        'appliances': [
+            {
+                'link_local_address': address_1,
+                'name': 'test-appliance',
+                'drive_failure_tolerance_level': 'Single'
+            }
+        ],
+        'dns_servers': [address_1],
+        'ntp_servers': [address_1],
+        'networks': [
+            {
+                'type': 'Management',
+                'vlan_id': 0,
+                'prefix_length': 21,
+                'gateway': address_1,
+                'cluster_mgmt_address': address_1,
+                'addresses': [address_1]
+            }
+        ],
+        'validate_create': True,
+        'is_http_redirect_enabled': True,
+        'state': "present"
+    }
+
     CLUSTER_COMMON_ARGS = {
         'array_ip': '**.***.**.***',
         'cluster_id': "0",
@@ -24,6 +65,16 @@ class MockClusterApi:
         'is_ssh_enabled': None,
         'physical_mtu': None,
         'new_name': None,
+        'appliances': None,
+        'physical_switches': None,
+        'dns_servers': None,
+        'ntp_servers': None,
+        'networks': None,
+        'vcenters': None,
+        'ignore_network_warnings': None,
+        'is_http_redirect_enabled': None,
+        'validate_create': None,
+        'wait_for_completion': None,
         'state': None
     }
 
@@ -48,9 +99,24 @@ class MockClusterApi:
         "system_time": "2022-01-21T06:36:59.050Z"
     }
 
-    @staticmethod
-    def get_cluster_failed_msg():
-        return "Creation of cluster is currently not supported"
+    APPLIANCE_DETAILS = {
+        'id': 'A1',
+        'name': 'test-appliance'
+    }
+
+    CLUSTER_LIST = [
+        {
+            "id": "0",
+            "name": "WN-ABCD"},
+        {
+            "id": "0",
+            "name": None}
+    ]
+    CLUSTER_LIST_1 = [
+        {
+            "id": "0",
+            "name": None}
+    ]
 
     @staticmethod
     def delete_cluster_failed_msg():
@@ -67,3 +133,73 @@ class MockClusterApi:
     @staticmethod
     def modify_cluster_failed_msg():
         return "Modify operation failed with error"
+
+    @staticmethod
+    def get_cluster_list_failed_msg():
+        return "Getting list of clusters failed with error"
+
+    @staticmethod
+    def cluster_addr_less_3_failed_msg():
+        return "For Management network, minimum 3 addresses for PowerStore"
+
+    @staticmethod
+    def dns_ntp_more_than_3_failed_msg():
+        return "Maximum three address should be provided"
+
+    @staticmethod
+    def link_local_address_failed_msg():
+        return "Provide valid link_local_address"
+
+    @staticmethod
+    def appliance_name_failed_msg():
+        return "Provide valid name of an appliance"
+
+    @staticmethod
+    def not_address_failed_msg():
+        return "The address should be provided"
+
+    @staticmethod
+    def invalid_cluster_name_failed_msg():
+        return "Provide valid "
+
+    @staticmethod
+    def invalid_vcenter_address_failed_msg():
+        return "Provide valid address for new vcenter configuration"
+
+    @staticmethod
+    def invalid_switch_name_failed_msg():
+        return "Provide valid physical switch name."
+
+    @staticmethod
+    def invalid_empty_connections_failed_msg():
+        return "connections details should be present in physical_switches."
+
+    @staticmethod
+    def without_mgmt_cluster_address_failed_msg():
+        return "The cluster_mgmt_address should be provided for Management"
+
+    @staticmethod
+    def invalid_cluster_address_failed_msg():
+        return "Provide valid cluster_mgmt_address"
+
+    @staticmethod
+    def invalid_storage_address_failed_msg():
+        return "Provide valid storage_discovery_address"
+
+    @staticmethod
+    def storage_address_in_mgmt_network_failed_msg():
+        return "storage_discovery_address and purposes should not be " \
+               "provided for management"
+
+    @staticmethod
+    def appliance_failed_msg():
+        return "Unable to fetch the appliance details"
+
+    @staticmethod
+    def service_user_failed_msg():
+        return "Get details of service user with id"
+
+    @staticmethod
+    def data_center_name_id_failed_msg():
+        return "parameters are mutually " \
+               "exclusive: data_center_name|data_center_id"

--- a/tests/unit/plugins/module_utils/mock_nasserver_api.py
+++ b/tests/unit/plugins/module_utils/mock_nasserver_api.py
@@ -23,18 +23,31 @@ class MockNasServerApi:
         'preferred_node': None,
         'current_unix_directory_service': None,
         'default_unix_user': None,
-        'default_windows_user': None
+        'default_windows_user': None,
+        'protection_policy': None
     }
     NAS_SERVER_NAME_1 = "Sample_nas_server_1"
 
-    NAS_SERVER_DETAILS = {
+    PROTECTION_POLICY_DETAILS = [{
+        "description": None,
+        "id": "bce845ea-78ba-4414-ada1-8130f3a49e74",
+        "name": "Sample_protection_policy",
+        "replication_rules": [{
+            "id": "7ec83605-bed4-4e2b-8405-504a614db318",
+            "name": "sample_replication_rule"
+        }],
+        "snapshot_rules": [],
+        "type": "Protection"
+    }]
+
+    NAS_SERVER_DETAILS = [{
         "backup_IPv4_interface_id": None,
         "backup_IPv6_interface_id": None,
         "current_node": {
             "id": "N2",
-            "name": "Appliance-WND8977-node-B"
+            "name": "Appliance-XXXXXXX-node-B"
         },
-        "current_node_id": "Appliance-WND8977-node-B",
+        "current_node_id": "Appliance-XXXXXXX-node-B",
         "current_preferred_IPv4_interface_id": "60c02-b5d8-9d9b-7e6f-feb93c9",
         "current_preferred_IPv6_interface_id": None,
         "current_unix_directory_service": "LDAP",
@@ -81,12 +94,75 @@ class MockNasServerApi:
         "preferred_node_id": "Appliance-XXXXXXX-node-B",
         "production_IPv4_interface_id": "60c05652-b5d8-9d9b-7e6f-fe8be1eb93c",
         "production_IPv6_interface_id": None,
+        "protection_policy_id": None,
         "smb_servers": [
             {
                 "id": "60c05c18-6806-26ae-3b0d-fe8be1eb93c"
             }
         ]
-    }
+    }]
+
+    NAS_SERVER_2_DETAILS = [{
+        "backup_IPv4_interface_id": None,
+        "backup_IPv6_interface_id": None,
+        "current_node": {
+            "id": "N2",
+            "name": "Appliance-XXXXXXX-node-B"
+        },
+        "current_node_id": "Appliance-XXXXXXX-node-B",
+        "current_preferred_IPv4_interface_id": "60c02-b5d8-9d9b-7e6f-feb93c9",
+        "current_preferred_IPv6_interface_id": None,
+        "current_unix_directory_service": "LDAP",
+        "current_unix_directory_service_l10n": "LDAP",
+        "default_unix_user": None,
+        "default_windows_user": None,
+        "description": "",
+        "file_interfaces":
+        [
+            {
+                "id": "0c05652-b5d8-9d9b-7e6f-fe8be1eb93c9",
+                "ip_address": "X.X.X.X",
+                "name": "PROD001_xxxxxxxx08a9_6"
+            }
+        ],
+        "file_ldaps":
+        [
+            {
+                "id": "60c05ba8-362e-159a-0205-ee6f605dfe5a"
+            }
+        ],
+        "file_nises": [],
+        "file_systems": [
+            {
+                "id": "61c55b57-4a70-08dd-a240-96e8abdcbab0",
+                "name": "sample_fs"
+            }
+        ],
+        "id": "60c0564a-4a6e-04b6-4d5e-fe8be1eb93c9",
+        "is_auto_user_mapping_enabled": True,
+        "is_username_translation_enabled": False,
+        "name": "Sample_nas_server_2",
+        "nfs_servers": [
+            {
+                "id": "60c05653-4fd3-2033-2da0-ee6f605dfe5a"
+            }
+        ],
+        "operational_status": "Started",
+        "operational_status_l10n": "Started",
+        "preferred_node": {
+            "id": "N2",
+            "name": "Appliance-XXXXXXX-node-B"
+        },
+        "preferred_node_id": "Appliance-XXXXXXX-node-B",
+        "production_IPv4_interface_id": "60c05652-b5d8-9d9b-7e6f-fe8be1eb93c",
+        "production_IPv6_interface_id": None,
+        "protection_policy_id": "bce845ea-78ba-4414-ada1-8130f3a49e74",
+        "smb_servers": [
+            {
+                "id": "60c05c18-6806-26ae-3b0d-fe8be1eb93c"
+            }
+        ]
+    }]
 
     NODE_DETAILS = [
         {

--- a/tests/unit/plugins/module_utils/mock_replicationsession_api.py
+++ b/tests/unit/plugins/module_utils/mock_replicationsession_api.py
@@ -19,6 +19,8 @@ class MockReplicationSessionApi:
         'array_ip': '**.***.**.***',
         'volume_group': None,
         'volume': None,
+        'nas_server': None,
+        'filesystem': None,
         'session_id': None,
         'session_state': None
     }
@@ -236,12 +238,84 @@ class MockReplicationSessionApi:
         }
     ]
 
+    REPLICATION_SESSION_DETAILS_NAS_SERVER = [
+        {
+            "id": "62a9b5c4-f82e-5668-3ea4-4ad525462806",
+            "state": "Partial_OK",
+            "role": "Destination",
+            "resource_type": "nas_server",
+            "data_transfer_state": "Asynchronous",
+            "type": "Asynchronous",
+            "last_sync_timestamp": None,
+            "local_resource_id": "629f413b-a583-9fac-a84b-4ad525462806",
+            "remote_resource_id": "62a7875c-042d-1885-be35-4ad525462806",
+            "remote_system_id": "57384c4e-0018-4464-829c-d567da38fac0",
+            "progress_percentage": None,
+            "estimated_completion_timestamp": None,
+            "replication_rule_id": "ea57f751-d4ea-4f37-9fce-4345d4ac3fb6",
+            "last_sync_duration": None,
+            "next_sync_timestamp": None,
+            "storage_element_pairs": None,
+            "failover_test_in_progress": False,
+            "error_code": None,
+            "data_connection_state": "OK",
+            "parent_replication_session_id": None,
+            "local_resource_state": None,
+            "state_l10n": "Partial OK",
+            "role_l10n": "Destination",
+            "resource_type_l10n": "NAS Server",
+            "data_transfer_state_l10n": "Asynchronous",
+            "type_l10n": "Asynchronous",
+            "data_connection_state_l10n": "OK",
+            "local_resource_state_l10n": None}
+    ]
+
+    REPLICATION_SESSION_DETAILS_FILESYSTEM = [
+        {
+            "id": "62a72cbf-36a0-c57a-04f0-da3630264434",
+            "state": "OK",
+            "role": "Source",
+            "resource_type": "file_system",
+            "data_transfer_state": None,
+            "type": "Asynchronous",
+            "last_sync_timestamp": "2022-07-06T10:25:40+00:00",
+            "local_resource_id": "629f3441-b76e-41ca-3f37-4ad525462806",
+            "remote_resource_id": "62a72ca3-a95b-4539-0641-da3630264434",
+            "remote_system_id": "57384c4e-0018-4464-829c-d567da38fac0",
+            "progress_percentage": None,
+            "estimated_completion_timestamp": None,
+            "replication_rule_id": "ea57f751-d4ea-4f37-9fce-4345d4ac3fb6",
+            "last_sync_duration": 2000,
+            "next_sync_timestamp": "2022-07-06T11:25:40+00:00",
+            "storage_element_pairs": None,
+            "failover_test_in_progress": False,
+            "error_code": None,
+            "data_connection_state": "OK",
+            "parent_replication_session_id": "62a72ca3-9efe-ce10-a94f-4ad525462806",
+            "local_resource_state": None,
+            "state_l10n": "OK",
+            "role_l10n": "Source",
+            "resource_type_l10n": "File System",
+            "data_transfer_state_l10n": None,
+            "type_l10n": "Asynchronous",
+            "data_connection_state_l10n": "OK",
+            "local_resource_state_l10n": None}
+    ]
+
     SESSION_IDS_VOLUME = [
         {'id': "b05b5108-26b6-4567-a1d8-1c7795b2e6bc"}
     ]
 
     SESSION_IDS_VOLUME_GROUP = [
         {'id': "b05b5108-26b6-4567-a1d8-1c7795b2e6bd"}
+    ]
+
+    SESSION_IDS_NAS_SERVER = [
+        {'id': "62a9b5c4-f82e-5668-3ea4-4ad525462806"}
+    ]
+
+    SESSION_IDS_FILESYSTEM = [
+        {'id': "62a72cbf-36a0-c57a-04f0-da3630264434"}
     ]
 
     VOLUME_DETAILS = [{
@@ -329,6 +403,92 @@ class MockReplicationSessionApi:
             "type_l10n": "Primary",
             "volumes": []
         }
+    ]
+
+    NAS_SERVER_DETAILS = [
+        {
+            "id": "6299d83a-37dc-340b-788f-4ad525462806",
+            "name": "sample_nas_server",
+            "description": None,
+            "operational_status": "Started",
+            "current_node_id": "Appliance-RT-D0338-node-B",
+            "preferred_node_id": "Appliance-RT-D0338-node-A",
+            "default_unix_user": None,
+            "default_windows_user": None,
+            "current_unix_directory_service": "None",
+            "is_username_translation_enabled": False,
+            "is_auto_user_mapping_enabled": False,
+            "production_IPv4_interface_id": None,
+            "production_IPv6_interface_id": None,
+            "backup_IPv4_interface_id": None,
+            "backup_IPv6_interface_id": None,
+            "current_preferred_IPv4_interface_id": "6299d84e-68e0-f4b2-c5e0-4ad525462806",
+            "current_preferred_IPv6_interface_id": None,
+            "protection_policy_id": "1df04c60-c098-40f2-929d-bb12ee3ea471",
+            "file_events_publishing_mode": "None",
+            "is_replication_destination": False,
+            "is_production_mode_enabled": True,
+            "operational_status_l10n": "Started",
+            "current_unix_directory_service_l10n": "None",
+            "file_events_publishing_mode_l10n": "None"}
+    ]
+
+    FILESYSTEM_DETAILS = [
+        {
+            "id": "629e34ae-2cf1-ca81-8ccd-4ad525462806",
+            "name": "File_TEST",
+            "description": None,
+            "nas_server_id": "6299d83a-37dc-340b-788f-4ad525462806",
+            "parent_id": None,
+            "filesystem_type": "Primary",
+            "size_total": 3221225472,
+            "size_used": 1621098496,
+            "config_type": "General",
+            "protection_policy_id": None,
+            "access_policy": "Native",
+            "locking_policy": "Advisory",
+            "folder_rename_policy": "All_Forbidden",
+            "is_smb_sync_writes_enabled": False,
+            "is_smb_op_locks_enabled": True,
+            "is_smb_no_notify_enabled": False,
+            "is_smb_notify_on_access_enabled": False,
+            "is_smb_notify_on_write_enabled": False,
+            "smb_notify_on_change_dir_depth": 512,
+            "is_async_MTime_enabled": False,
+            "is_quota_enabled": False,
+            "grace_period": 604800,
+            "default_hard_limit": 0,
+            "default_soft_limit": 0,
+            "creation_timestamp": None,
+            "expiration_timestamp": None,
+            "last_refresh_timestamp": None,
+            "last_writable_timestamp": None,
+            "is_modified": None,
+            "access_type": None,
+            "creator_type": None,
+            "file_events_publishing_mode": "None",
+            "flr_attributes": {
+                "mode": "None",
+                "minimum_retention": "0D",
+                "default_retention": "0D",
+                "maximum_retention": "0D",
+                "auto_lock": False,
+                "auto_delete": False,
+                "policy_interval": 0,
+                "has_protected_files": False,
+                "clock_time": None,
+                "maximum_retention_date": None
+            },
+            "host_io_size": None,
+            "filesystem_type_l10n": "Primary File system",
+            "config_type_l10n": "General",
+            "access_policy_l10n": "Native",
+            "locking_policy_l10n": "Advisory",
+            "folder_rename_policy_l10n": "All Renames Forbidden",
+            "access_type_l10n": None,
+            "creator_type_l10n": None,
+            "file_events_publishing_mode_l10n": "None",
+            "host_io_size_l10n": None}
     ]
 
     REPLICATION_SESSION_DETAILS_SYNC = [
@@ -696,3 +856,7 @@ class MockReplicationSessionApi:
     @staticmethod
     def paused_to_sync_dest_error_failed_msg():
         return "Synchronization at destination is not supported."
+
+    @staticmethod
+    def volume_not_found_failed_msg():
+        return "not found"

--- a/tests/unit/plugins/module_utils/mock_volumegroup_api.py
+++ b/tests/unit/plugins/module_utils/mock_volumegroup_api.py
@@ -23,6 +23,11 @@ class MockVolumeGroupApi:
         'new_vg_name': None,
         'volumes': None,
         'vol_state': None,
+        'source_snap': None,
+        'source_vg': None,
+        'create_backup_snap': None,
+        'backup_snap_profile': None,
+        'vg_clone': None,
         'state': None
     }
     DESCRIPTION1 = 'Volume group created'
@@ -246,3 +251,15 @@ class MockVolumeGroupApi:
     @staticmethod
     def get_non_existing_volume_failed_msg():
         return "Volume with id 6b730a66-494a-4aea-88d2-45552bb4adfc not found. Please enter a correct volume id"
+
+    @staticmethod
+    def refresh_vol_group_ex():
+        return "Refreshing volume group 634e4b95-e7bd-49e7-957b-6dc932642464 failed with error"
+
+    @staticmethod
+    def restore_vol_group_ex():
+        return "Restoring volume group 634e4b95-e7bd-49e7-957b-6dc932642464 failed with error"
+
+    @staticmethod
+    def clone_vol_group_ex():
+        return "Cloning volume group 634e4b95-e7bd-49e7-957b-6dc932642464 failed with error"

--- a/tests/unit/plugins/modules/test_cluster.py
+++ b/tests/unit/plugins/modules/test_cluster.py
@@ -53,6 +53,7 @@ class TestPowerstoreCluster():
     def test_get_cluster_response_cluster_name(self, cluster_module_mock):
         self.get_module_args.update({
             'cluster_name': "WX-D9023",
+            'validate_create': False,
             'state': "present"
         })
         cluster_module_mock.module.params = self.get_module_args
@@ -123,20 +124,20 @@ class TestPowerstoreCluster():
         assert MockClusterApi.delete_cluster_failed_msg() in \
             cluster_module_mock.module.fail_json.call_args[1]['msg']
 
-    def test_get_non_existing_cluster_details(self, cluster_module_mock):
+    def test_get_cluster_list_exception(self, cluster_module_mock):
         MockApiException.HTTP_ERR = "1"
         MockApiException.err_code = "1"
         MockApiException.status_code = "404"
-        invalid_cluster_id = 2
         self.get_module_args.update({
-            'cluster_id': invalid_cluster_id,
+            'cluster_id': 0,
+            'create_validate': False,
             'state': "present"
         })
         cluster_module_mock.module.params = self.get_module_args
-        cluster_module_mock.configuration.get_cluster_details = MagicMock(
+        cluster_module_mock.provisioning.get_cluster_list = MagicMock(
             side_effect=MockApiException)
         cluster_module_mock.perform_module_operation()
-        assert MockClusterApi.get_cluster_failed_msg() in \
+        assert MockClusterApi.get_cluster_list_failed_msg() in \
             cluster_module_mock.module.fail_json.call_args[1]['msg']
 
     def test_modify_invalid_physical_mtu(self, cluster_module_mock):
@@ -146,9 +147,12 @@ class TestPowerstoreCluster():
         self.get_module_args.update({
             'cluster_id': "0",
             'physical_mtu': 100,
+            'validate_create': False,
             'state': "present"
         })
         cluster_module_mock.module.params = self.get_module_args
+        cluster_module_mock.provisioning.get_cluster_list = MagicMock(
+            return_value=MockClusterApi.CLUSTER_LIST)
         cluster_module_mock.configuration.get_cluster_details = MagicMock(
             return_value=MockClusterApi.CLUSTER_DETAILS)
         cluster_module_mock.configuration.modify_cluster = MagicMock(
@@ -156,3 +160,305 @@ class TestPowerstoreCluster():
         cluster_module_mock.perform_module_operation()
         assert MockClusterApi.modify_cluster_failed_msg() in \
             cluster_module_mock.module.fail_json.call_args[1]['msg']
+
+    def test_validate_create_cluster(self, cluster_module_mock):
+        self.get_module_args.update(MockClusterApi.MODIFIED_PARAMS)
+        cluster_module_mock.module.params = self.get_module_args
+        cluster_module_mock.provisioning.get_cluster_list = MagicMock(
+            return_value=MockClusterApi.CLUSTER_LIST_1)
+        cluster_module_mock.perform_module_operation()
+        cluster_module_mock.configuration.cluster_create_validate.assert_called()
+
+    def test_create_cluster(self, cluster_module_mock):
+        MockClusterApi.MODIFIED_PARAMS['validate_create'] = False
+        MockClusterApi.MODIFIED_PARAMS['wait_for_completion'] = True
+        self.get_module_args.update(MockClusterApi.MODIFIED_PARAMS)
+        cluster_module_mock.module.params = self.get_module_args
+        cluster_module_mock.get_cluster_list = MagicMock(
+            return_value=MockClusterApi.CLUSTER_LIST_1)
+        cluster_module_mock.perform_module_operation()
+        cluster_module_mock.configuration.cluster_create.assert_called()
+
+    def test_cluster_less_than_3_network_address(self, cluster_module_mock):
+        self.get_module_args.update(MockClusterApi.MODIFIED_PARAMS)
+        cluster_module_mock.module.params = self.get_module_args
+        cluster_module_mock.provisioning.get_cluster_list = MagicMock(
+            return_value=MockClusterApi.CLUSTER_LIST_1)
+        cluster_module_mock.perform_module_operation()
+        assert MockClusterApi.cluster_addr_less_3_failed_msg() in \
+               cluster_module_mock.module.fail_json.call_args[1]['msg']
+
+    def test_cluster_more_than_3_dns(self, cluster_module_mock):
+        MockClusterApi.MODIFIED_PARAMS['dns_servers'] = [
+            MockClusterApi.address_1, MockClusterApi.address_1,
+            MockClusterApi.address_1, MockClusterApi.address_1]
+        MockClusterApi.MODIFIED_PARAMS['networks'][0]['addresses'] = [
+            MockClusterApi.address_1, MockClusterApi.address_1,
+            MockClusterApi.address_1]
+        self.get_module_args.update(MockClusterApi.MODIFIED_PARAMS)
+        cluster_module_mock.module.params = self.get_module_args
+        cluster_module_mock.provisioning.get_cluster_list = MagicMock(
+            return_value=MockClusterApi.CLUSTER_LIST_1)
+        cluster_module_mock.perform_module_operation()
+        assert MockClusterApi.dns_ntp_more_than_3_failed_msg() in \
+               cluster_module_mock.module.fail_json.call_args[1]['msg']
+
+    def test_cluster_more_than_3_ntp(self, cluster_module_mock):
+        MockClusterApi.MODIFIED_PARAMS['ntp_servers'] = [
+            MockClusterApi.address_1, MockClusterApi.address_1,
+            MockClusterApi.address_1, MockClusterApi.address_1]
+        MockClusterApi.MODIFIED_PARAMS['networks'][0]['addresses'] = [
+            MockClusterApi.address_1, MockClusterApi.address_1,
+            MockClusterApi.address_1]
+        self.get_module_args.update(MockClusterApi.MODIFIED_PARAMS)
+        cluster_module_mock.module.params = self.get_module_args
+        cluster_module_mock.provisioning.get_cluster_list = MagicMock(
+            return_value=MockClusterApi.CLUSTER_LIST_1)
+        cluster_module_mock.perform_module_operation()
+        assert MockClusterApi.dns_ntp_more_than_3_failed_msg() in \
+               cluster_module_mock.module.fail_json.call_args[1]['msg']
+
+    def test_cluster_invalid_link_local_address(self, cluster_module_mock):
+        MockClusterApi.MODIFIED_PARAMS['appliances'][
+            0]['link_local_address'] = MockClusterApi.invalid_address_1
+        MockClusterApi.MODIFIED_PARAMS['networks'][0]['addresses'] = [
+            MockClusterApi.address_1, MockClusterApi.address_1,
+            MockClusterApi.address_1]
+        self.get_module_args.update(MockClusterApi.MODIFIED_PARAMS)
+        cluster_module_mock.module.params = self.get_module_args
+        cluster_module_mock.provisioning.get_cluster_list = MagicMock(
+            return_value=MockClusterApi.CLUSTER_LIST_1)
+        cluster_module_mock.perform_module_operation()
+        assert MockClusterApi.link_local_address_failed_msg() in \
+               cluster_module_mock.module.fail_json.call_args[1]['msg']
+
+    def test_cluster_invalid_appliance_name(self, cluster_module_mock):
+        MockClusterApi.MODIFIED_PARAMS['appliances'][0]['name'] = MockClusterApi.invalid_name
+        MockClusterApi.MODIFIED_PARAMS['networks'][0]['addresses'] = [
+            MockClusterApi.address_1, MockClusterApi.address_1,
+            MockClusterApi.address_1]
+        self.get_module_args.update(MockClusterApi.MODIFIED_PARAMS)
+        cluster_module_mock.module.params = self.get_module_args
+        cluster_module_mock.provisioning.get_cluster_list = MagicMock(
+            return_value=MockClusterApi.CLUSTER_LIST_1)
+        cluster_module_mock.perform_module_operation()
+        assert MockClusterApi.appliance_name_failed_msg() in \
+               cluster_module_mock.module.fail_json.call_args[1]['msg']
+
+    def test_cluster_with_invalid_address_for_switch(self, cluster_module_mock):
+        MockClusterApi.MODIFIED_PARAMS['physical_switches'] = [{
+            'name': 'test-appliance',
+            'purpose': 'Management_Only',
+            'connections': [{
+                'address': ' ',
+                'connect_method': 'SSH',
+                'username': 'user',
+                'ssh_password': 'xxxx'
+            }]
+        }]
+        MockClusterApi.MODIFIED_PARAMS['networks'][0]['addresses'] = [
+            MockClusterApi.address_1, MockClusterApi.address_1,
+            MockClusterApi.address_1]
+        self.get_module_args.update(MockClusterApi.MODIFIED_PARAMS)
+        cluster_module_mock.module.params = self.get_module_args
+        cluster_module_mock.provisioning.get_cluster_list = MagicMock(
+            return_value=MockClusterApi.CLUSTER_LIST_1)
+        cluster_module_mock.perform_module_operation()
+        assert MockClusterApi.not_address_failed_msg() in \
+               cluster_module_mock.module.fail_json.call_args[1]['msg']
+
+    def test_get_cluster_response_empty_cluster_name(self, cluster_module_mock):
+        self.get_module_args.update({
+            'cluster_name': " ",
+            'state': "present"
+        })
+        cluster_module_mock.module.params = self.get_module_args
+        cluster_module_mock.provisioning.get_cluster_list = MagicMock(
+            return_value=MockClusterApi.CLUSTER_LIST_1)
+        cluster_module_mock.perform_module_operation()
+        assert MockClusterApi.invalid_cluster_name_failed_msg() in \
+               cluster_module_mock.module.fail_json.call_args[1]['msg']
+
+    def test_cluster_with_invalid_vcenter_address(self, cluster_module_mock):
+        MockClusterApi.MODIFIED_PARAMS['vcenters'] = [{
+            'address': '  ',
+            'username': 'user',
+            'password': 'xxxx',
+            'is_verify_server_cert': True,
+            'vasa_provider_credentials': {
+                'username': 'user',
+                'password': 'xxxx'
+            }
+        }]
+        MockClusterApi.MODIFIED_PARAMS['networks'][0]['addresses'] = [
+            MockClusterApi.address_1, MockClusterApi.address_1,
+            MockClusterApi.address_1]
+        self.get_module_args.update(MockClusterApi.MODIFIED_PARAMS)
+        cluster_module_mock.module.params = self.get_module_args
+        cluster_module_mock.provisioning.get_cluster_list = MagicMock(
+            return_value=MockClusterApi.CLUSTER_LIST_1)
+        cluster_module_mock.perform_module_operation()
+        assert MockClusterApi.invalid_vcenter_address_failed_msg() in \
+               cluster_module_mock.module.fail_json.call_args[1]['msg']
+
+    def test_cluster_with_invalid_switch_name(self, cluster_module_mock):
+        MockClusterApi.MODIFIED_PARAMS['physical_switches'] = [{
+            'name': MockClusterApi.invalid_name,
+            'purpose': 'Management_Only',
+            'connections': [{
+                'address': MockClusterApi.address_1,
+                'connect_method': 'SSH',
+                'username': 'user',
+                'ssh_password': 'xxxx'
+            }]
+        }]
+        MockClusterApi.MODIFIED_PARAMS['networks'][0]['addresses'] = [
+            MockClusterApi.address_1, MockClusterApi.address_1,
+            MockClusterApi.address_1]
+        self.get_module_args.update(MockClusterApi.MODIFIED_PARAMS)
+        cluster_module_mock.module.params = self.get_module_args
+        cluster_module_mock.provisioning.get_cluster_list = MagicMock(
+            return_value=MockClusterApi.CLUSTER_LIST_1)
+        cluster_module_mock.perform_module_operation()
+        assert MockClusterApi.invalid_switch_name_failed_msg() in \
+               cluster_module_mock.module.fail_json.call_args[1]['msg']
+
+    def test_cluster_without_connections(self, cluster_module_mock):
+        MockClusterApi.MODIFIED_PARAMS['physical_switches'] = [{
+            'name': 'phy_switch_name',
+            'purpose': 'Management_Only',
+            'connections': []
+        }]
+        MockClusterApi.MODIFIED_PARAMS['networks'][0]['addresses'] = [
+            MockClusterApi.address_1, MockClusterApi.address_1,
+            MockClusterApi.address_1]
+        self.get_module_args.update(MockClusterApi.MODIFIED_PARAMS)
+        cluster_module_mock.module.params = self.get_module_args
+        cluster_module_mock.provisioning.get_cluster_list = MagicMock(
+            return_value=MockClusterApi.CLUSTER_LIST_1)
+        cluster_module_mock.perform_module_operation()
+        assert MockClusterApi.invalid_empty_connections_failed_msg() in \
+               cluster_module_mock.module.fail_json.call_args[1]['msg']
+
+    def test_cluster_without_mgmt_cluster_address(self, cluster_module_mock):
+        MockClusterApi.MODIFIED_PARAMS['networks'][
+            0]['cluster_mgmt_address'] = None
+        MockClusterApi.MODIFIED_PARAMS['networks'][0]['addresses'] = [
+            MockClusterApi.address_1, MockClusterApi.address_1,
+            MockClusterApi.address_1]
+        self.get_module_args.update(MockClusterApi.MODIFIED_PARAMS)
+        cluster_module_mock.module.params = self.get_module_args
+        cluster_module_mock.provisioning.get_cluster_list = MagicMock(
+            return_value=MockClusterApi.CLUSTER_LIST_1)
+        cluster_module_mock.perform_module_operation()
+        assert MockClusterApi.without_mgmt_cluster_address_failed_msg() in \
+               cluster_module_mock.module.fail_json.call_args[1]['msg']
+
+    def test_cluster_with_invalid_cluster_mgmt(self, cluster_module_mock):
+        MockClusterApi.MODIFIED_PARAMS['networks'][
+            0]['cluster_mgmt_address'] = MockClusterApi.invalid_address_1
+        MockClusterApi.MODIFIED_PARAMS['networks'][0]['addresses'] = [
+            MockClusterApi.address_1, MockClusterApi.address_1,
+            MockClusterApi.address_1]
+        self.get_module_args.update(MockClusterApi.MODIFIED_PARAMS)
+        cluster_module_mock.module.params = self.get_module_args
+        cluster_module_mock.provisioning.get_cluster_list = MagicMock(
+            return_value=MockClusterApi.CLUSTER_LIST_1)
+        cluster_module_mock.perform_module_operation()
+        assert MockClusterApi.invalid_cluster_address_failed_msg() in \
+               cluster_module_mock.module.fail_json.call_args[1]['msg']
+
+    def test_cluster_with_invalid_storage_discovery(self, cluster_module_mock):
+        MockClusterApi.MODIFIED_PARAMS['networks'][0]['addresses'] = [
+            MockClusterApi.address_1, MockClusterApi.address_1,
+            MockClusterApi.address_1]
+        MockClusterApi.MODIFIED_PARAMS['networks'].append(MockClusterApi.NET_DICT)
+        self.get_module_args.update(MockClusterApi.MODIFIED_PARAMS)
+        cluster_module_mock.module.params = self.get_module_args
+        cluster_module_mock.provisioning.get_cluster_list = MagicMock(
+            return_value=MockClusterApi.CLUSTER_LIST_1)
+        cluster_module_mock.perform_module_operation()
+        assert MockClusterApi.invalid_storage_address_failed_msg() in \
+               cluster_module_mock.module.fail_json.call_args[1]['msg']
+
+    def test_cluster_with_storage_discovery_in_mgmt_network(self, cluster_module_mock):
+        MockClusterApi.MODIFIED_PARAMS['networks'][
+            0]['storage_discovery_address'] = MockClusterApi.invalid_address_1
+        MockClusterApi.MODIFIED_PARAMS['networks'][0]['addresses'] = [
+            MockClusterApi.address_1, MockClusterApi.address_1,
+            MockClusterApi.address_1]
+        self.get_module_args.update(MockClusterApi.MODIFIED_PARAMS)
+        cluster_module_mock.module.params = self.get_module_args
+        cluster_module_mock.provisioning.get_cluster_list = MagicMock(
+            return_value=MockClusterApi.CLUSTER_LIST_1)
+        cluster_module_mock.perform_module_operation()
+        assert MockClusterApi.storage_address_in_mgmt_network_failed_msg() in \
+               cluster_module_mock.module.fail_json.call_args[1]['msg']
+
+    def test_get_appliance_exception(self, cluster_module_mock):
+        MockApiException.HTTP_ERR = "1"
+        MockApiException.err_code = "1"
+        MockApiException.status_code = "404"
+        self.get_module_args.update({'cluster_name': MockClusterApi.cluster_name,
+                                     'appliance_id': "A1",
+                                     'is_ssh_enabled': True,
+                                     'physical_mtu': 3000,
+                                     'state': "present"})
+        cluster_module_mock.module.params = self.get_module_args
+        cluster_module_mock.provisioning.get_cluster_list = MagicMock(
+            return_value=MockClusterApi.CLUSTER_LIST_1)
+        cluster_module_mock.configuration.get_cluster_by_name = MagicMock(
+            return_value=MockClusterApi.CLUSTER_DETAILS)
+        cluster_module_mock.configuration.get_appliance_details = MagicMock(
+            side_effect=MockApiException)
+        cluster_module_mock.perform_module_operation()
+        assert MockClusterApi.appliance_failed_msg() in \
+               cluster_module_mock.module.fail_json.call_args[1]['msg']
+
+    def test_get_service_user_exception(self, cluster_module_mock):
+        MockApiException.HTTP_ERR = "1"
+        MockApiException.err_code = "1"
+        MockApiException.status_code = "404"
+        self.get_module_args.update({'cluster_name': MockClusterApi.cluster_name,
+                                     'appliance_id': "A1",
+                                     'is_ssh_enabled': True,
+                                     'physical_mtu': 3000,
+                                     'state': "present"})
+        cluster_module_mock.module.params = self.get_module_args
+        cluster_module_mock.provisioning.get_cluster_list = MagicMock(
+            return_value=MockClusterApi.CLUSTER_LIST)
+        cluster_module_mock.get_appliance_details = MagicMock(
+            return_values=MockClusterApi.APPLIANCE_DETAILS)
+        cluster_module_mock.get_cluster_details = MagicMock(
+            return_value=MockClusterApi.CLUSTER_DETAILS)
+        cluster_module_mock.configuration.get_service_user_details = MagicMock(
+            side_effect=MockApiException)
+        cluster_module_mock.get_appliance_details = MagicMock(
+            return_values=MockClusterApi.APPLIANCE_DETAILS)
+        cluster_module_mock.perform_module_operation()
+        assert MockClusterApi.service_user_failed_msg() in \
+               cluster_module_mock.module.fail_json.call_args[1]['msg']
+
+    def test_cluster_with_data_center_name_id(self, cluster_module_mock):
+        MockClusterApi.MODIFIED_PARAMS['vcenters'] = [{
+            'address': MockClusterApi.address_1,
+            'username': 'user',
+            'password': 'xxxx',
+            'data_center_name': 'center_name',
+            'data_center_id': 'center_id',
+            'is_verify_server_cert': True,
+            'vasa_provider_credentials': {
+                'username': 'user',
+                'password': 'xxxx'
+            }
+        }]
+        MockClusterApi.MODIFIED_PARAMS['networks'][0]['addresses'] = [
+            MockClusterApi.address_1, MockClusterApi.address_1,
+            MockClusterApi.address_1]
+        self.get_module_args.update(MockClusterApi.MODIFIED_PARAMS)
+        cluster_module_mock.module.params = self.get_module_args
+        cluster_module_mock.provisioning.get_cluster_list = MagicMock(
+            return_value=MockClusterApi.CLUSTER_LIST_1)
+        cluster_module_mock.perform_module_operation()
+        assert MockClusterApi.data_center_name_id_failed_msg() in \
+               cluster_module_mock.module.fail_json.call_args[1]['msg']

--- a/tests/unit/plugins/modules/test_nasserver.py
+++ b/tests/unit/plugins/modules/test_nasserver.py
@@ -44,7 +44,7 @@ class TestPowerstoreNasServer():
         })
         nasserver_module_mock.module.params = self.get_module_args
         nasserver_module_mock.provisioning.get_nas_server_details = MagicMock(
-            return_value=MockNasServerApi.NAS_SERVER_DETAILS)
+            return_value=MockNasServerApi.NAS_SERVER_DETAILS[0])
         nasserver_module_mock.perform_module_operation()
         assert self.get_module_args['nas_server_id'] == nasserver_module_mock.module.exit_json.call_args[1]['nasserver_details']['id']
         nasserver_module_mock.provisioning.get_nas_server_details.assert_called()
@@ -56,7 +56,7 @@ class TestPowerstoreNasServer():
         })
         nasserver_module_mock.module.params = self.get_module_args
         nasserver_module_mock.provisioning.get_nas_server_details = MagicMock(
-            return_value=MockNasServerApi.NAS_SERVER_DETAILS)
+            return_value=MockNasServerApi.NAS_SERVER_DETAILS[0])
         nasserver_module_mock.perform_module_operation()
         assert self.get_module_args['nas_server_name'] == nasserver_module_mock.module.exit_json.call_args[1]['nasserver_details']['name']
         nasserver_module_mock.provisioning.get_nas_server_by_name.assert_called()
@@ -94,7 +94,7 @@ class TestPowerstoreNasServer():
         })
         nasserver_module_mock.module.params = self.get_module_args
         nasserver_module_mock.provisioning.get_nas_server_details = MagicMock(
-            return_value=MockNasServerApi.NAS_SERVER_DETAILS)
+            return_value=MockNasServerApi.NAS_SERVER_DETAILS[0])
         nasserver_module_mock.perform_module_operation()
         assert MockNasServerApi.delete_nas_server_failed_msg() in \
             nasserver_module_mock.module.fail_json.call_args[1]['msg']
@@ -107,11 +107,50 @@ class TestPowerstoreNasServer():
             'current_unix_directory_service': "LOCAL_FILES",
             'default_unix_user': "admin",
             'default_windows_user': "admin",
+            'protection_policy': "Sample_protection_policy",
             'state': "present"
         })
         nasserver_module_mock.module.params = self.get_module_args
-        nasserver_module_mock.provisioning.get_nas_server_details = MagicMock(
+        nasserver_module_mock.provisioning.get_nas_server_by_name = MagicMock(
             return_value=MockNasServerApi.NAS_SERVER_DETAILS)
+        nasserver_module_mock.provisioning.get_nas_server_details = MagicMock(
+            return_value=MockNasServerApi.NAS_SERVER_DETAILS[0])
+        nasserver_module_mock.provisioning.get_nodes = MagicMock(
+            return_value=MockNasServerApi.NODE_DETAILS)
+        nasserver_module_mock.protection.get_protection_policy_by_name = MagicMock(
+            return_value=MockNasServerApi.PROTECTION_POLICY_DETAILS)
+        nasserver_module_mock.perform_module_operation()
+        nasserver_module_mock.provisioning.modify_nasserver.assert_called()
+
+    def test_add_protection_policy_by_id_response(self, nasserver_module_mock):
+        self.get_module_args.update({
+            'nas_server_name': "Sample_nas_server_1",
+            'protection_policy': "bce845ea-78ba-4414-ada1-8130f3a49e74",
+            'state': "present"
+        })
+        nasserver_module_mock.module.params = self.get_module_args
+        nasserver_module_mock.provisioning.get_nas_server_by_name = MagicMock(
+            return_value=MockNasServerApi.NAS_SERVER_DETAILS)
+        nasserver_module_mock.provisioning.get_nas_server_details = MagicMock(
+            return_value=MockNasServerApi.NAS_SERVER_DETAILS[0])
+        nasserver_module_mock.provisioning.get_nodes = MagicMock(
+            return_value=MockNasServerApi.NODE_DETAILS)
+        nasserver_module_mock.protection.get_protection_policy_details = MagicMock(
+            return_value=MockNasServerApi.PROTECTION_POLICY_DETAILS[0])
+        nasserver_module_mock.perform_module_operation()
+        nasserver_module_mock.provisioning.modify_nasserver.assert_called()
+
+    def test_remove_protection_policy_response(self, nasserver_module_mock):
+        self.get_module_args.update({
+            'nas_server_name': "Sample_nas_server_2",
+            'protection_policy': "",
+            'state': "present"
+        })
+        nasserver_module_mock.module.params = self.get_module_args
+        nasserver_module_mock.provisioning.get_nas_server_by_name = MagicMock(
+            return_value=MockNasServerApi.NAS_SERVER_2_DETAILS)
+        nasserver_module_mock.provisioning.get_nas_server_details = MagicMock(
+            return_value=MockNasServerApi.NAS_SERVER_2_DETAILS[0])
         nasserver_module_mock.provisioning.get_nodes = MagicMock(
             return_value=MockNasServerApi.NODE_DETAILS)
         nasserver_module_mock.perform_module_operation()
@@ -126,7 +165,7 @@ class TestPowerstoreNasServer():
         })
         nasserver_module_mock.module.params = self.get_module_args
         nasserver_module_mock.provisioning.get_nas_server_details = MagicMock(
-            return_value=MockNasServerApi.NAS_SERVER_DETAILS)
+            return_value=MockNasServerApi.NAS_SERVER_DETAILS[0])
         nasserver_module_mock.provisioning.get_nodes = MagicMock(
             return_value=MockNasServerApi.NODE_DETAILS)
         nasserver_module_mock.perform_module_operation()
@@ -144,7 +183,7 @@ class TestPowerstoreNasServer():
         })
         nasserver_module_mock.module.params = self.get_module_args
         nasserver_module_mock.provisioning.get_nas_server_details = MagicMock(
-            return_value=MockNasServerApi.NAS_SERVER_DETAILS)
+            return_value=MockNasServerApi.NAS_SERVER_DETAILS[0])
         nasserver_module_mock.provisioning.get_nodes = MagicMock(
             return_value=MockNasServerApi.NODE_DETAILS)
         nasserver_module_mock.provisioning.modify_nasserver = MagicMock(
@@ -159,7 +198,7 @@ class TestPowerstoreNasServer():
         })
         nasserver_module_mock.module.params = self.get_module_args
         nasserver_module_mock.provisioning.get_nas_server_details = MagicMock(
-            return_value=MockNasServerApi.NAS_SERVER_DETAILS)
+            return_value=MockNasServerApi.NAS_SERVER_DETAILS[0])
         nasserver_module_mock.provisioning.get_cluster_list = MagicMock(
             return_value=MockNasServerApi.CLUSTER_DETAILS)
         nasserver_module_mock.perform_module_operation()

--- a/tests/unit/plugins/modules/test_replicationsession.py
+++ b/tests/unit/plugins/modules/test_replicationsession.py
@@ -65,6 +65,37 @@ class TestPowerstoreReplicationSession():
         replicationsession_module_mock.perform_module_operation()
         replicationsession_module_mock.conn.protection.get_replication_session_details.assert_called()
 
+    def test_get_replication_session_using_volume_id_response(self, replicationsession_module_mock):
+        self.get_module_args.update({
+            'volume': "634e4b95-e7bd-49e7-957b-6dc932642464"
+        })
+        replicationsession_module_mock.module.params = self.get_module_args
+        replicationsession_module_mock.protection.get_replication_session_details = MagicMock(
+            return_value=MockReplicationSessionApi.REPLICATION_SESSION_DETAILS[0])
+        replicationsession_module_mock.protection.get_replication_sessions = MagicMock(
+            return_value=MockReplicationSessionApi.SESSION_IDS_VOLUME)
+        replicationsession_module_mock.provisioning.get_volume_details = MagicMock(
+            return_value=MockReplicationSessionApi.VOLUME_DETAILS[0])
+        replicationsession_module_mock.perform_module_operation()
+        replicationsession_module_mock.conn.protection.get_replication_session_details.assert_called()
+
+    def test_get_replication_session_using_volume_not_found_response(self, replicationsession_module_mock):
+        MockApiException.HTTP_ERR = "1"
+        MockApiException.err_code = "1"
+        MockApiException.status_code = "404"
+        self.get_module_args.update({
+            'volume': "634e4b95-e7bd-49e7-957b-6dc932642464"
+        })
+        replicationsession_module_mock.module.params = self.get_module_args
+        replicationsession_module_mock.protection.get_replication_session_details = MagicMock(
+            return_value=MockReplicationSessionApi.REPLICATION_SESSION_DETAILS[0])
+        replicationsession_module_mock.protection.get_replication_sessions = MagicMock(
+            return_value=MockReplicationSessionApi.SESSION_IDS_VOLUME)
+        replicationsession_module_mock.provisioning.get_volume_details = MagicMock(
+            side_effect=MockApiException)
+        replicationsession_module_mock.perform_module_operation()
+        replicationsession_module_mock.conn.provisioning.get_volume_details.assert_called()
+
     def test_get_replication_session_using_volume_group_response(self, replicationsession_module_mock):
         self.get_module_args.update({
             'volume_group': "sample_volume_group"
@@ -78,6 +109,38 @@ class TestPowerstoreReplicationSession():
             return_value=MockReplicationSessionApi.VOLUME_GROUP_DETAILS)
         replicationsession_module_mock.provisioning.get_volume_group_details = MagicMock(
             return_value=MockReplicationSessionApi.VOLUME_GROUP_DETAILS[0])
+        replicationsession_module_mock.perform_module_operation()
+        replicationsession_module_mock.conn.protection.get_replication_session_details.assert_called()
+
+    def test_get_replication_session_using_nas_server_response(self, replicationsession_module_mock):
+        self.get_module_args.update({
+            'nas_server': "sample_nas_server"
+        })
+        replicationsession_module_mock.module.params = self.get_module_args
+        replicationsession_module_mock.protection.get_replication_session_details = MagicMock(
+            return_value=MockReplicationSessionApi.REPLICATION_SESSION_DETAILS_NAS_SERVER[0])
+        replicationsession_module_mock.protection.get_replication_sessions = MagicMock(
+            return_value=MockReplicationSessionApi.SESSION_IDS_NAS_SERVER)
+        replicationsession_module_mock.provisioning.get_nas_server_by_name = MagicMock(
+            return_value=MockReplicationSessionApi.NAS_SERVER_DETAILS)
+        replicationsession_module_mock.provisioning.get_nas_server_details = MagicMock(
+            return_value=MockReplicationSessionApi.NAS_SERVER_DETAILS[0])
+        replicationsession_module_mock.perform_module_operation()
+        replicationsession_module_mock.conn.protection.get_replication_session_details.assert_called()
+
+    def test_get_replication_session_using_filesystem_response(self, replicationsession_module_mock):
+        self.get_module_args.update({
+            'filesystem': "sample_filesystem"
+        })
+        replicationsession_module_mock.module.params = self.get_module_args
+        replicationsession_module_mock.protection.get_replication_session_details = MagicMock(
+            return_value=MockReplicationSessionApi.REPLICATION_SESSION_DETAILS_FILESYSTEM[0])
+        replicationsession_module_mock.protection.get_replication_sessions = MagicMock(
+            return_value=MockReplicationSessionApi.SESSION_IDS_FILESYSTEM)
+        replicationsession_module_mock.provisioning.get_filesystem_by_name = MagicMock(
+            return_value=MockReplicationSessionApi.FILESYSTEM_DETAILS)
+        replicationsession_module_mock.provisioning.get_filesystem_details = MagicMock(
+            return_value=MockReplicationSessionApi.FILESYSTEM_DETAILS[0])
         replicationsession_module_mock.perform_module_operation()
         replicationsession_module_mock.conn.protection.get_replication_session_details.assert_called()
 

--- a/tests/unit/plugins/modules/test_volumegroup.py
+++ b/tests/unit/plugins/modules/test_volumegroup.py
@@ -330,3 +330,102 @@ class TestPowerstoreVolumeGroup():
         volume_group_module_mock.perform_module_operation()
         assert MockVolumeGroupApi.get_non_existing_volume_failed_msg() in \
                volume_group_module_mock.module.fail_json.call_args[1]['msg']
+
+    def test_refresh_volume_group(self, volume_group_module_mock):
+        self.get_module_args.update({
+            'vg_name': "sample_volume_group",
+            'source_vg': "src_volume_group",
+            'create_backup_snap': "true",
+            'backup_snap_profile': {'name': 'backup_test'},
+            'state': "present"
+        })
+        volume_group_module_mock.module.params = self.get_module_args
+        volume_group_module_mock.get_volume_group_details = MagicMock(
+            return_value=MockVolumeGroupApi.VG_DETAILS[0])
+        volume_group_module_mock.validate_input = MagicMock(return_value=True)
+        volume_group_module_mock.get_snapshots_of_volume_group = MagicMock(return_value=(None, None))
+        volume_group_module_mock.perform_module_operation()
+        volume_group_module_mock.provisioning.refresh_volume_group.assert_called()
+
+    def test_refresh_volume_group_throws_ex(self, volume_group_module_mock):
+        self.get_module_args.update({
+            'vg_name': "sample_volume_group",
+            'source_vg': "src_volume_group",
+            'create_backup_snap': "true",
+            'backup_snap_profile': {'name': 'backup_test'},
+            'state': "present"
+        })
+        volume_group_module_mock.module.params = self.get_module_args
+        volume_group_module_mock.get_volume_group_details = MagicMock(
+            return_value=MockVolumeGroupApi.VG_DETAILS[0])
+        volume_group_module_mock.validate_input = MagicMock(return_value=True)
+        volume_group_module_mock.get_snapshots_of_volume_group = MagicMock(return_value=None)
+        volume_group_module_mock.provisioning.refresh_volume_group = MagicMock(side_effect=Exception)
+        volume_group_module_mock.perform_module_operation()
+        assert MockVolumeGroupApi.refresh_vol_group_ex() in \
+               volume_group_module_mock.module.fail_json.call_args[1]['msg']
+
+    def test_restore_volume_group(self, volume_group_module_mock):
+        self.get_module_args.update({
+            'vg_name': "sample_volume_group",
+            'source_snap': "src_volume_group",
+            'create_backup_snap': "true",
+            'backup_snap_profile': {'name': 'backup_test'},
+            'state': "present"
+        })
+        volume_group_module_mock.module.params = self.get_module_args
+        volume_group_module_mock.get_volume_group_details = MagicMock(
+            return_value=MockVolumeGroupApi.VG_DETAILS[0])
+        volume_group_module_mock.validate_input = MagicMock(return_value=True)
+        volume_group_module_mock.get_snapshots_of_volume_group = MagicMock(return_value=[None, MagicMock()])
+        volume_group_module_mock.perform_module_operation()
+        volume_group_module_mock.provisioning.restore_volume_group.assert_called()
+
+    def test_restore_volume_group_throws_ex(self, volume_group_module_mock):
+        self.get_module_args.update({
+            'vg_name': "sample_volume_group",
+            'source_snap': "src_volume_group",
+            'create_backup_snap': "true",
+            'backup_snap_profile': {'name': 'backup_test'},
+            'state': "present"
+        })
+        volume_group_module_mock.module.params = self.get_module_args
+        volume_group_module_mock.get_volume_group_details = MagicMock(
+            return_value=MockVolumeGroupApi.VG_DETAILS[0])
+        volume_group_module_mock.validate_input = MagicMock(return_value=True)
+        volume_group_module_mock.get_snapshots_of_volume_group = MagicMock(return_value=[None, MagicMock()])
+        volume_group_module_mock.provisioning.restore_volume_group = MagicMock(side_effect=Exception)
+        volume_group_module_mock.perform_module_operation()
+        print(volume_group_module_mock.module.fail_json.call_args[1]['msg'])
+        assert MockVolumeGroupApi.restore_vol_group_ex() in \
+               volume_group_module_mock.module.fail_json.call_args[1]['msg']
+
+    def test_clone_volume_group(self, volume_group_module_mock):
+        self.get_module_args.update({
+            'vg_name': "sample_volume_group",
+            'vg_clone': {'name': 'clone_test', 'protection_policy': None, 'description': None},
+            'state': "present"
+        })
+        volume_group_module_mock.module.params = self.get_module_args
+        volume_group_module_mock.provisioning.get_volume_group_details = MagicMock(
+            return_value=MockVolumeGroupApi.VG_DETAILS[0])
+        volume_group_module_mock.provisioning.get_volume_group_by_name = MagicMock(
+            return_value=None)
+        volume_group_module_mock.perform_module_operation()
+        volume_group_module_mock.provisioning.clone_volume_group.assert_called()
+
+    def test_clone_volume_group_throws_ex(self, volume_group_module_mock):
+        self.get_module_args.update({
+            'vg_name': "sample_volume_group",
+            'vg_clone': {'name': 'clone_test', 'protection_policy': None, 'description': None},
+            'state': "present"
+        })
+        volume_group_module_mock.module.params = self.get_module_args
+        volume_group_module_mock.provisioning.get_volume_group_details = MagicMock(
+            return_value=MockVolumeGroupApi.VG_DETAILS[0])
+        volume_group_module_mock.provisioning.get_volume_group_by_name = MagicMock(
+            return_value=None)
+        volume_group_module_mock.provisioning.clone_volume_group = MagicMock(side_effect=Exception)
+        volume_group_module_mock.perform_module_operation()
+        assert MockVolumeGroupApi.clone_vol_group_ex() in \
+               volume_group_module_mock.module.fail_json.call_args[1]['msg']


### PR DESCRIPTION
# Description
Ansible Modules for PowerStore release version 1.7.0 include:

Validate the creation and create a cluster.
Associate and disassociate a protection policy to/from a NAS server.
Manage replication sessions for filesystems and NAS servers.
Clone/Restore/Refresh a volume group.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|[#14](https://github.com/dell/ansible-powerstore/issues/14)|

# Checklist:

- [X] I have performed a self-review of my own code to ensure there are no formatting, pep8, linting, or security issues
- [X] I have performed the Ansible Sanity test using --docker default
- [X] I have verified that new and existing unit tests pass locally with my changes
- [X] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [X] I have commented on my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] Backward compatibility is not broken

# How Has This Been Tested?

- [X] Functional Testing
- [X] Regression Testing
- [X] Unit Testing
