### PR TITLE
list valid values for access_type in filesystem_snapshot

### DIFF
--- a/docs/modules/filesystem_snapshot.rst
+++ b/docs/modules/filesystem_snapshot.rst
@@ -76,6 +76,7 @@ Parameters
 
   access_type (optional, str, None)
     Specifies whether the snapshot directory or protocol access is granted to the filesystem snapshot.
+    Value of access_type must be one of: ``SNAPSHOT``, ``PROTOCOL``
 
     For create operation, if *access_type* is not specified, snapshot will be created with ``SNAPSHOT`` access type.
 


### PR DESCRIPTION
# Description
List the explicit values that are accepted since there are only two values which must be ALL CAPS.


# Checklist:
- [X] I have made corresponding changes to the documentation


# How Has This Been Tested?
Tried using values other than ``SNAPSHOT`` or ``PROTOCOL`` and received error stating 
> value of access_type must be one of: SNAPSHOT, PROTOCOL

- [X] tried with incorrect string (failed as expected)
- [X] tried with lowercase string (failed as expected)
- [X] tried with correct string and capitalization (succeeded)
