### PR TITLE
Limit to disable Mamagement_HTTP service by update

### DIFF
--- a/plugins/modules/certificate.py
+++ b/plugins/modules/certificate.py
@@ -414,6 +414,10 @@ class PowerStoreCertificate(object):
                 modify_dict['is_current'] = is_current
 
             if modify_dict:
+                if not modify_dict['is_current'] and cert_details['service'] == "Management_HTTP":
+                    msg = 'cannot disable `is_current` for Management_HTTP service'
+                    LOG.error(msg)
+                    self.module.fail_json(msg=msg)
                 return modify_dict
             else:
                 return None

--- a/tests/unit/plugins/module_utils/mock_certificate_api.py
+++ b/tests/unit/plugins/module_utils/mock_certificate_api.py
@@ -54,6 +54,12 @@ class MockCertificateApi:
     }
 
     @staticmethod
+    def get_modify_certificate_details(service="Syslog_HTTP"):
+        cert_detail = MockCertificateApi.MODIFY_CERTIFICATE_DETAILS.copy()
+        cert_detail['service'] = service
+        return cert_detail
+
+    @staticmethod
     def create_certificates_wo_service_failed_msg():
         return "Please provide valid/existing certificate_id"
 
@@ -80,3 +86,7 @@ class MockCertificateApi:
     @staticmethod
     def create_certificate_certificate_id_failed_msg():
         return "certificate_id is not accepted while adding a certificate"
+
+    @staticmethod
+    def modify_management_certificate_failed_msg():
+        return "cannot disable `is_current` for Management_HTTP service"

--- a/tests/unit/plugins/modules/test_certificate.py
+++ b/tests/unit/plugins/modules/test_certificate.py
@@ -103,6 +103,17 @@ class TestPowerstoreCertificate():
         certificate_module_mock.perform_module_operation()
         assert certificate_module_mock.module.exit_json.call_args[1]['changed'] is True
 
+    def test_modify_management_certificate(self, certificate_module_mock):
+        self.get_module_args.update({'certificate_id': "f19b38ac-4b8b-45b1-96eb-abe4faae51ca",
+                                     'is_current': False,
+                                     'state': "present"})
+        certificate_module_mock.module.params = self.get_module_args
+        certificate_module_mock.configuration.get_certificate_details = MagicMock(
+            return_value=MockCertificateApi.get_modify_certificate_details("Management_HTTP"))
+        certificate_module_mock.perform_module_operation()
+        assert MockCertificateApi.modify_management_certificate_failed_msg() in \
+            certificate_module_mock.module.fail_json.call_args[1]['msg']
+
     def test_delete_certificate(self, certificate_module_mock):
         certificate_id = "f19b38ac-4b8b-45b1-96eb-abe4faae51ca"
         self.get_module_args.update({'certificate_id': certificate_id,


### PR DESCRIPTION
# Description
Limit to disable Mamagement_HTTP service by update

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, pep8, linting, or security issues
- [x] I have performed Ansible Sanity test using --docker default
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] UT
