### PR TITLE
Fix quota Windows name format

### DIFF
--- a/plugins/modules/quota.py
+++ b/plugins/modules/quota.py
@@ -545,6 +545,8 @@ class PowerStoreQuota(object):
             if path and filesystem_id:
                 tree_quota_id = self.get_tree_quota_id(path, filesystem_id)
             uid = str(uid) if uid is not None else None
+            if win_name:
+                win_name = win_name.split('\\')[0].lower() + "\\" + win_name.split('\\')[1]
             query_params_dict = create_params_dict(
                 uid=uid, unix_name=unix_name, windows_sid=win_sid,
                 windows_name=win_name, tree_quota_id=tree_quota_id,


### PR DESCRIPTION
# Description
With user win name, quota details can't be retrieved while being modified.
User win name consists of domain name and user name, and Powerstore only accepts domain name in uppercase (DOMAIN/username) as param. However, it stores the domain name in lowercase (domain/username). So when the quota is being modified, Ansible can't find the user since there's no user with domain name in uppercase in Powerstore backend.
So, before getting quota details, change the domain name back to lowercase to match up.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, pep8, linting, or security issues
- [x] I have performed Ansible Sanity test using --docker default
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B
