### PR TITLE
ECS02-343: Deliver support for RecycleBin

### DIFF
--- a/docs/modules/recycle_bin.rst
+++ b/docs/modules/recycle_bin.rst
@@ -1,0 +1,259 @@
+.. _recycle_bin_module:
+
+
+recycle_bin -- Manage Recycle Bin on PowerStore storage systems
+==============================================================
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+
+Manage Recycle Bin on PowerStore storage systems includes configuring the recycle bin expiration duration, recovering deleted volumes and volume groups from the recycle bin, permanently deleting items from the recycle bin, and emptying the entire recycle bin.
+
+This module supports check mode and diff mode.
+
+
+
+Requirements
+------------
+The below requirements are needed on the host that executes this module.
+
+- A Dell PowerStore storage system version 3.5.0.0 or later.
+- PyPowerStore 3.4.2 or later.
+
+
+
+Parameters
+----------
+
+  recycle_bin_id (optional, str, None)
+    The unique identifier of the recycle bin item.
+
+    Required for recover and delete operations.
+
+    Mutually exclusive with *resource_name*.
+
+
+  resource_name (optional, str, None)
+    The name of the deleted resource in the recycle bin.
+
+    Used as an alternative to *recycle_bin_id* for identifying items.
+
+    Mutually exclusive with *recycle_bin_id*.
+
+
+  resource_type (optional, str, None)
+    The type of resource to filter when using *resource_name*.
+
+    Used to disambiguate when multiple items share the same name.
+
+
+  expiration_duration (optional, int, None)
+    Duration in days for items to remain in the recycle bin before automatic permanent deletion.
+
+    Valid range is 0 to 30 days. A value of 0 means items expire immediately.
+
+    Used only with *state=present* to configure the recycle bin retention policy.
+
+
+  empty_recycle_bin (optional, bool, False)
+    When set to :literal:`true` and *state=absent*, empties the entire recycle bin by permanently deleting all items.
+
+    Cannot be used together with *recycle_bin_id* or *resource_name*.
+
+
+  state (True, str, None)
+    Define the operation to perform on the recycle bin.
+
+    :literal:`present` with *expiration_duration* configures the retention policy.
+
+    :literal:`present` with *recycle_bin_id* or *resource_name* recovers items from the recycle bin.
+
+    :literal:`absent` with *recycle_bin_id* or *resource_name* permanently deletes items from the recycle bin.
+
+    :literal:`absent` with *empty_recycle_bin=true* empties the entire recycle bin.
+
+
+  array_ip (True, str, None)
+    IP or FQDN of the PowerStore management system.
+
+
+  validate_certs (optional, bool, True)
+    Boolean variable to specify whether to validate SSL certificate or not.
+
+    :literal:`true` - indicates that the SSL certificate should be verified. Set the environment variable REQUESTS\_CA\_BUNDLE to the path of the SSL certificate.
+
+    :literal:`false` - indicates that the SSL certificate should not be verified.
+
+
+  user (True, str, None)
+    The username of the PowerStore host.
+
+
+  password (True, str, None)
+    The password of the PowerStore host.
+
+
+  timeout (optional, int, 120)
+    Time after which the connection will get terminated.
+
+    It is to be mentioned in seconds.
+
+
+  port (optional, int, None)
+    Port number for the PowerStore array.
+
+    If not passed, it will take 443 as default.
+
+
+
+
+
+Notes
+-----
+
+.. note::
+   - The :emphasis:`check\_mode` is supported.
+   - The :emphasis:`diff` mode is supported.
+   - Recycle Bin feature requires PowerStore version 3.5.0.0 or later.
+   - The modules present in this collection named as 'dellemc.powerstore' are built to support the Dell PowerStore storage platform.
+
+
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: Get recycle bin configuration
+      dellemc.powerstore.recycle_bin:
+        array_ip: "{{ array_ip }}"
+        user: "{{ user }}"
+        password: "{{ password }}"
+        validate_certs: "{{ validate_certs }}"
+        state: "present"
+
+    - name: Configure recycle bin expiration to 14 days
+      dellemc.powerstore.recycle_bin:
+        array_ip: "{{ array_ip }}"
+        user: "{{ user }}"
+        password: "{{ password }}"
+        validate_certs: "{{ validate_certs }}"
+        expiration_duration: 14
+        state: "present"
+
+    - name: Recover a volume from recycle bin by ID
+      dellemc.powerstore.recycle_bin:
+        array_ip: "{{ array_ip }}"
+        user: "{{ user }}"
+        password: "{{ password }}"
+        validate_certs: "{{ validate_certs }}"
+        recycle_bin_id: "e0684b39-0029-4be2-b5bf-67b8c145e1b8"
+        state: "present"
+
+    - name: Recover a volume from recycle bin by name
+      dellemc.powerstore.recycle_bin:
+        array_ip: "{{ array_ip }}"
+        user: "{{ user }}"
+        password: "{{ password }}"
+        validate_certs: "{{ validate_certs }}"
+        resource_name: "my_volume"
+        resource_type: "volume"
+        state: "present"
+
+    - name: Permanently delete a specific item from recycle bin
+      dellemc.powerstore.recycle_bin:
+        array_ip: "{{ array_ip }}"
+        user: "{{ user }}"
+        password: "{{ password }}"
+        validate_certs: "{{ validate_certs }}"
+        recycle_bin_id: "e0684b39-0029-4be2-b5bf-67b8c145e1b8"
+        state: "absent"
+
+    - name: Empty the entire recycle bin
+      dellemc.powerstore.recycle_bin:
+        array_ip: "{{ array_ip }}"
+        user: "{{ user }}"
+        password: "{{ password }}"
+        validate_certs: "{{ validate_certs }}"
+        empty_recycle_bin: true
+        state: "absent"
+
+
+
+Return Values
+-------------
+
+changed (always, bool, true)
+  Whether or not the resource has changed.
+
+
+recycle_bin_config (When expiration_duration is provided or no item operation is performed, complex, {'id': '0', 'expiration_duration': 7})
+  Details of the recycle bin configuration.
+
+
+  id (, str, )
+    Unique identifier for recycle bin configuration (always "0").
+
+
+  expiration_duration (, int, )
+    Duration in days for items to remain in the recycle bin.
+
+
+recycle_bin_items (When getting recycle bin details without specific item operations, list, [{'id': 'e0684b39-0029-4be2-b5bf-67b8c145e1b8', 'name': 'test_volume', 'resource_type': 'volume', 'logical_provisioned': 1073741824, 'logical_used': 0, 'appliance_id': 'A1', 'deletion_timestamp': '2024-01-01T00:00:00.000+00:00', 'expiration_timestamp': '2024-01-08T00:00:00.000+00:00'}])
+  List of items currently in the recycle bin.
+
+
+  id (, str, )
+    Unique identifier of the recycle bin item.
+
+
+  name (, str, )
+    Name of the deleted resource.
+
+
+  resource_type (, str, )
+    Type of resource (volume or volume_group).
+
+
+  logical_provisioned (, int, )
+    Provisioned size of the object in bytes.
+
+
+  logical_used (, int, )
+    Logical space used by the object in bytes.
+
+
+  appliance_id (, str, )
+    The appliance where the resource is located.
+
+
+  deletion_timestamp (, str, )
+    Time when the object was moved to the recycle bin.
+
+
+  expiration_timestamp (, str, )
+    Time when the object will be auto-purged.
+
+
+
+
+
+
+Status
+------
+
+
+
+
+
+Authors
+~~~~~~~
+
+- Ansible Team <ansible.team@dell.com>

--- a/playbooks/modules/recycle_bin.yml
+++ b/playbooks/modules/recycle_bin.yml
@@ -1,0 +1,99 @@
+---
+- name: Recycle Bin module operations on PowerStore storage system
+  hosts: localhost
+  connection: local
+  vars:
+    array_ip: "10.**.**.**"
+    validate_certs: false
+    user: "user"
+    password: "Password"
+
+  tasks:
+    - name: Get recycle bin configuration and items
+      dellemc.powerstore.recycle_bin:
+        array_ip: "{{ array_ip }}"
+        validate_certs: "{{ validate_certs }}"
+        user: "{{ user }}"
+        password: "{{ password }}"
+        state: "present"
+      register: recycle_bin_details
+
+    - name: Display recycle bin configuration
+      ansible.builtin.debug:
+        var: recycle_bin_details
+
+    - name: Configure recycle bin expiration to 14 days
+      dellemc.powerstore.recycle_bin:
+        array_ip: "{{ array_ip }}"
+        validate_certs: "{{ validate_certs }}"
+        user: "{{ user }}"
+        password: "{{ password }}"
+        expiration_duration: 14
+        state: "present"
+
+    - name: Configure recycle bin expiration to 14 days - Idempotency
+      dellemc.powerstore.recycle_bin:
+        array_ip: "{{ array_ip }}"
+        validate_certs: "{{ validate_certs }}"
+        user: "{{ user }}"
+        password: "{{ password }}"
+        expiration_duration: 14
+        state: "present"
+
+    - name: Configure recycle bin expiration to 7 days
+      dellemc.powerstore.recycle_bin:
+        array_ip: "{{ array_ip }}"
+        validate_certs: "{{ validate_certs }}"
+        user: "{{ user }}"
+        password: "{{ password }}"
+        expiration_duration: 7
+        state: "present"
+
+    - name: Recover a volume from recycle bin by ID
+      dellemc.powerstore.recycle_bin:
+        array_ip: "{{ array_ip }}"
+        validate_certs: "{{ validate_certs }}"
+        user: "{{ user }}"
+        password: "{{ password }}"
+        recycle_bin_id: "{{ recycle_bin_item_id | default(omit) }}"
+        state: "present"
+      when: recycle_bin_item_id is defined
+
+    - name: Recover a volume from recycle bin by name
+      dellemc.powerstore.recycle_bin:
+        array_ip: "{{ array_ip }}"
+        validate_certs: "{{ validate_certs }}"
+        user: "{{ user }}"
+        password: "{{ password }}"
+        resource_name: "{{ recycle_bin_resource_name | default(omit) }}"
+        resource_type: "volume"
+        state: "present"
+      when: recycle_bin_resource_name is defined
+
+    - name: Permanently delete a specific item from recycle bin
+      dellemc.powerstore.recycle_bin:
+        array_ip: "{{ array_ip }}"
+        validate_certs: "{{ validate_certs }}"
+        user: "{{ user }}"
+        password: "{{ password }}"
+        recycle_bin_id: "{{ recycle_bin_delete_id | default(omit) }}"
+        state: "absent"
+      when: recycle_bin_delete_id is defined
+
+    - name: Empty the entire recycle bin
+      dellemc.powerstore.recycle_bin:
+        array_ip: "{{ array_ip }}"
+        validate_certs: "{{ validate_certs }}"
+        user: "{{ user }}"
+        password: "{{ password }}"
+        empty_recycle_bin: true
+        state: "absent"
+
+    - name: Empty the entire recycle bin - Idempotency
+      dellemc.powerstore.recycle_bin:
+        array_ip: "{{ array_ip }}"
+        validate_certs: "{{ validate_certs }}"
+        user: "{{ user }}"
+        password: "{{ password }}"
+        empty_recycle_bin: true
+        state: "absent"

--- a/plugins/modules/info.py
+++ b/plugins/modules/info.py
@@ -86,6 +86,7 @@ options:
     - File NIS - C(file_nis).
     - Service configs - C(service_configs).
     - SNMP managers - C(snmp_manager).
+    - Recycle bin items - C(recycle_bin).
     required: true
     elements: str
     choices: [vol, vg, host, hg, node, protection_policy, snapshot_rule,
@@ -96,7 +97,8 @@ options:
               email_notification, remote_support, remote_support_contact,
               ldap_domain, vcenter, virtual_volume, storage_container,
               replication_group, discovered_appliance, file_interface,
-              smb_server, nfs_server, file_dns, file_nis, service_config, snmp_manager]
+              smb_server, nfs_server, file_dns, file_nis, service_config, snmp_manager,
+              recycle_bin]
     type: list
   filters:
     description:
@@ -418,6 +420,15 @@ EXAMPLES = r'''
     password: "{{password}}"
     gather_subset:
       - snmp_manager
+
+- name: Get list of recycle bin items
+  dellemc.powerstore.info:
+    array_ip: "{{array_ip}}"
+    validate_certs: "{{validate_certs}}"
+    user: "{{user}}"
+    password: "{{password}}"
+    gather_subset:
+      - recycle_bin
 '''
 
 RETURN = r'''
@@ -2180,9 +2191,41 @@ class PowerstoreInfo(object):
             'snmp_manager': {
                 'func': self.snmp_manager.get_snmp_server_list,
                 'display_as': 'snmp_managers'
+            },
+            'recycle_bin': {
+                'func': self._get_recycle_bin_items,
+                'display_as': 'RecycleBin'
             }
         }
         LOG.info('Got Py4ps connection object %s', self.conn)
+
+    def _get_recycle_bin_items(self, filter_dict=None, all_pages=False):
+        """Get all items in the recycle bin via direct REST call."""
+        url = 'https://{0}/api/rest/recycle_bin'.format(
+            self.provisioning.server_ip)
+        resp = self.provisioning.client.request(
+            'GET', url, querystring={'select': '*'})
+        if resp is None:
+            resp = []
+        if filter_dict:
+            filtered = []
+            for item in resp:
+                match = True
+                for key, val in filter_dict.items():
+                    item_val = str(item.get(key, ''))
+                    if isinstance(val, str):
+                        if val.startswith('eq.') and item_val != val[3:]:
+                            match = False
+                        elif val.startswith('neq.') and item_val == val[4:]:
+                            match = False
+                        elif val.startswith('ilike.'):
+                            pattern = val[6:].replace('*', '')
+                            if pattern.lower() not in item_val.lower():
+                                match = False
+                if match:
+                    filtered.append(item)
+            resp = filtered
+        return resp
 
     def get_acl(self, smb_share_id):
         """
@@ -2362,7 +2405,8 @@ def get_powerstore_info_parameters():
                      'ldap_account', 'ldap_domain', 'vcenter',
                      'virtual_volume', 'storage_container',
                      'replication_group', 'discovered_appliance', 'file_interface',
-                     'smb_server', 'nfs_server', 'file_dns', 'file_nis', 'service_config']),
+                     'smb_server', 'nfs_server', 'file_dns', 'file_nis', 'service_config',
+                     'recycle_bin']),
         filters=dict(type='list', required=False, elements='dict',
                      options=dict(filter_key=dict(type='str', required=True,
                                                   no_log=False),

--- a/plugins/modules/recycle_bin.py
+++ b/plugins/modules/recycle_bin.py
@@ -26,7 +26,7 @@ extends_documentation_fragment:
   - dellemc.powerstore.powerstore
 
 author:
-- Ansible Team <ansible.team@dell.com>
+- Saksham Nautiyal (@saksham-nautiyal) <ansible.team@dell.com>
 
 options:
   recycle_bin_id:

--- a/plugins/modules/recycle_bin.py
+++ b/plugins/modules/recycle_bin.py
@@ -1,0 +1,550 @@
+#!/usr/bin/python
+# Copyright: (c) 2024, Dell Technologies
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Ansible module for managing Recycle Bin on PowerStore"""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+---
+module: recycle_bin
+version_added: '3.9.0'
+
+short_description: Manage Recycle Bin on PowerStore storage systems
+
+description:
+- Manage Recycle Bin on PowerStore storage systems includes configuring
+  the recycle bin expiration duration, recovering deleted volumes and
+  volume groups from the recycle bin, permanently deleting items from
+  the recycle bin, and emptying the entire recycle bin.
+- This module supports check mode and diff mode.
+
+extends_documentation_fragment:
+  - dellemc.powerstore.powerstore
+
+author:
+- Ansible Team <ansible.team@dell.com>
+
+options:
+  recycle_bin_id:
+    description:
+    - The unique identifier of the recycle bin item.
+    - Required for recover and delete operations.
+    - Mutually exclusive with I(resource_name).
+    type: str
+  resource_name:
+    description:
+    - The name of the deleted resource in the recycle bin.
+    - Used as an alternative to I(recycle_bin_id) for identifying items.
+    - Mutually exclusive with I(recycle_bin_id).
+    type: str
+  resource_type:
+    description:
+    - The type of resource to filter when using I(resource_name).
+    - Used to disambiguate when multiple items share the same name.
+    type: str
+    choices: ['volume', 'volume_group']
+  expiration_duration:
+    description:
+    - Duration in days for items to remain in the recycle bin before
+      automatic permanent deletion.
+    - Valid range is 0 to 30 days. A value of 0 means items expire
+      immediately.
+    - Used only with I(state=present) to configure the recycle bin
+      retention policy.
+    type: int
+  empty_recycle_bin:
+    description:
+    - When set to C(true) and I(state=absent), empties the entire
+      recycle bin by permanently deleting all items.
+    - Cannot be used together with I(recycle_bin_id) or I(resource_name).
+    type: bool
+    default: false
+  state:
+    description:
+    - Define the operation to perform on the recycle bin.
+    - C(present) with I(expiration_duration) configures the retention
+      policy.
+    - C(present) with I(recycle_bin_id) or I(resource_name) recovers
+      items from the recycle bin.
+    - C(absent) with I(recycle_bin_id) or I(resource_name) permanently
+      deletes items from the recycle bin.
+    - C(absent) with I(empty_recycle_bin=true) empties the entire
+      recycle bin.
+    choices: ['absent', 'present']
+    required: true
+    type: str
+notes:
+- The I(check_mode) is supported.
+- The I(diff) mode is supported.
+- Recycle Bin feature requires PowerStore version 3.5.0.0 or later.
+'''
+
+EXAMPLES = r'''
+- name: Get recycle bin configuration
+  dellemc.powerstore.recycle_bin:
+    array_ip: "{{ array_ip }}"
+    user: "{{ user }}"
+    password: "{{ password }}"
+    validate_certs: "{{ validate_certs }}"
+    state: "present"
+
+- name: Configure recycle bin expiration to 14 days
+  dellemc.powerstore.recycle_bin:
+    array_ip: "{{ array_ip }}"
+    user: "{{ user }}"
+    password: "{{ password }}"
+    validate_certs: "{{ validate_certs }}"
+    expiration_duration: 14
+    state: "present"
+
+- name: Recover a volume from recycle bin by ID
+  dellemc.powerstore.recycle_bin:
+    array_ip: "{{ array_ip }}"
+    user: "{{ user }}"
+    password: "{{ password }}"
+    validate_certs: "{{ validate_certs }}"
+    recycle_bin_id: "e0684b39-0029-4be2-b5bf-67b8c145e1b8"
+    state: "present"
+
+- name: Recover a volume from recycle bin by name
+  dellemc.powerstore.recycle_bin:
+    array_ip: "{{ array_ip }}"
+    user: "{{ user }}"
+    password: "{{ password }}"
+    validate_certs: "{{ validate_certs }}"
+    resource_name: "my_volume"
+    resource_type: "volume"
+    state: "present"
+
+- name: Permanently delete a specific item from recycle bin
+  dellemc.powerstore.recycle_bin:
+    array_ip: "{{ array_ip }}"
+    user: "{{ user }}"
+    password: "{{ password }}"
+    validate_certs: "{{ validate_certs }}"
+    recycle_bin_id: "e0684b39-0029-4be2-b5bf-67b8c145e1b8"
+    state: "absent"
+
+- name: Empty the entire recycle bin
+  dellemc.powerstore.recycle_bin:
+    array_ip: "{{ array_ip }}"
+    user: "{{ user }}"
+    password: "{{ password }}"
+    validate_certs: "{{ validate_certs }}"
+    empty_recycle_bin: true
+    state: "absent"
+'''
+
+RETURN = r'''
+changed:
+    description: Whether or not the resource has changed.
+    returned: always
+    type: bool
+    sample: "true"
+recycle_bin_config:
+    description: Details of the recycle bin configuration.
+    returned: When I(expiration_duration) is provided or no item
+              operation is performed.
+    type: complex
+    contains:
+        id:
+            description: Unique identifier for recycle bin configuration
+                         (always "0").
+            type: str
+        expiration_duration:
+            description: Duration in days for items to remain in the
+                         recycle bin.
+            type: int
+    sample: {
+        "id": "0",
+        "expiration_duration": 7
+    }
+recycle_bin_items:
+    description: List of items currently in the recycle bin.
+    returned: When getting recycle bin details without specific item
+              operations.
+    type: list
+    contains:
+        id:
+            description: Unique identifier of the recycle bin item.
+            type: str
+        name:
+            description: Name of the deleted resource.
+            type: str
+        resource_type:
+            description: Type of resource (volume or volume_group).
+            type: str
+        logical_provisioned:
+            description: Provisioned size of the object in bytes.
+            type: int
+        logical_used:
+            description: Logical space used by the object in bytes.
+            type: int
+        appliance_id:
+            description: The appliance where the resource is located.
+            type: str
+        deletion_timestamp:
+            description: Time when the object was moved to the recycle
+                         bin.
+            type: str
+        expiration_timestamp:
+            description: Time when the object will be auto-purged.
+            type: str
+    sample: [{
+        "id": "e0684b39-0029-4be2-b5bf-67b8c145e1b8",
+        "name": "test_volume",
+        "resource_type": "volume",
+        "logical_provisioned": 1073741824,
+        "logical_used": 0,
+        "appliance_id": "A1",
+        "deletion_timestamp": "2024-01-01T00:00:00.000+00:00",
+        "expiration_timestamp": "2024-01-08T00:00:00.000+00:00"
+    }]
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.dellemc.powerstore.plugins.module_utils.storage.dell\
+    import utils
+
+LOG = utils.get_logger('recycle_bin')
+
+py4ps_sdk = utils.has_pyu4ps_sdk()
+HAS_PY4PS = py4ps_sdk['HAS_Py4PS']
+IMPORT_ERROR = py4ps_sdk['Error_message']
+
+py4ps_version = utils.py4ps_version_check()
+IS_SUPPORTED_PY4PS_VERSION = py4ps_version['supported_version']
+VERSION_ERROR = py4ps_version['unsupported_version_message']
+
+# REST API URL templates
+RECYCLE_BIN_CONFIG_URL = 'https://{0}/api/rest/recycle_bin_config/0'
+RECYCLE_BIN_LIST_URL = 'https://{0}/api/rest/recycle_bin'
+RECYCLE_BIN_ITEM_URL = 'https://{0}/api/rest/recycle_bin/{1}'
+RECYCLE_BIN_RECOVER_URL = 'https://{0}/api/rest/recycle_bin/{1}/recover'
+RECYCLE_BIN_EMPTY_URL = 'https://{0}/api/rest/recycle_bin/empty'
+
+
+class PowerStoreRecycleBin(object):
+    """Recycle Bin operations"""
+
+    def __init__(self):
+        """Define all parameters required by this module"""
+        self.module_params = utils.get_powerstore_management_host_parameters()
+        self.module_params.update(get_powerstore_recycle_bin_parameters())
+
+        mutually_exclusive = [['recycle_bin_id', 'resource_name'],
+                              ['recycle_bin_id', 'empty_recycle_bin'],
+                              ['resource_name', 'empty_recycle_bin']]
+
+        self.module = AnsibleModule(
+            argument_spec=self.module_params,
+            supports_check_mode=True,
+            mutually_exclusive=mutually_exclusive
+        )
+
+        msg = 'HAS_PY4PS = {0} , IMPORT_ERROR = {1}'.format(
+            HAS_PY4PS, IMPORT_ERROR)
+        LOG.info(msg)
+        if HAS_PY4PS is False:
+            self.module.fail_json(msg=IMPORT_ERROR)
+
+        msg = 'IS_SUPPORTED_PY4PS_VERSION = {0} , VERSION_ERROR = {1}'.format(
+            IS_SUPPORTED_PY4PS_VERSION, VERSION_ERROR)
+        LOG.info(msg)
+        if IS_SUPPORTED_PY4PS_VERSION is False:
+            self.module.fail_json(msg=VERSION_ERROR)
+
+        self.conn = utils.get_powerstore_connection(self.module.params)
+        self.provisioning = self.conn.provisioning
+        LOG.info('Got Py4ps instance for provisioning on PowerStore %s',
+                 self.provisioning)
+
+    def _api_request(self, method, url, payload=None, querystring=None):
+        """Make a REST API request using the SDK client."""
+        return self.provisioning.client.request(
+            method, url, payload=payload, querystring=querystring)
+
+    def get_recycle_bin_config(self):
+        """Get the recycle bin configuration."""
+        try:
+            LOG.info("Getting recycle bin configuration.")
+            url = RECYCLE_BIN_CONFIG_URL.format(self.provisioning.server_ip)
+            resp = self._api_request('GET', url,
+                                     querystring={'select': '*'})
+            LOG.info("Recycle bin config: %s", resp)
+            return resp
+        except Exception as e:
+            msg = "Failed to get recycle bin configuration with " \
+                  "error {0}".format(str(e))
+            LOG.error(msg)
+            self.module.fail_json(msg=msg, **utils.failure_codes(e))
+
+    def get_recycle_bin_items(self):
+        """Get all items in the recycle bin."""
+        try:
+            LOG.info("Getting recycle bin items.")
+            url = RECYCLE_BIN_LIST_URL.format(self.provisioning.server_ip)
+            resp = self._api_request('GET', url,
+                                     querystring={'select': '*'})
+            if resp is None:
+                resp = []
+            LOG.info("Recycle bin items count: %s", len(resp))
+            return resp
+        except Exception as e:
+            msg = "Failed to get recycle bin items with " \
+                  "error {0}".format(str(e))
+            LOG.error(msg)
+            self.module.fail_json(msg=msg, **utils.failure_codes(e))
+
+    def get_recycle_bin_item(self, item_id):
+        """Get a specific recycle bin item by ID."""
+        try:
+            LOG.info("Getting recycle bin item with ID: %s", item_id)
+            url = RECYCLE_BIN_ITEM_URL.format(
+                self.provisioning.server_ip, item_id)
+            resp = self._api_request('GET', url,
+                                     querystring={'select': '*'})
+            LOG.info("Recycle bin item: %s", resp)
+            return resp
+        except Exception as e:
+            msg = "Failed to get recycle bin item {0} with " \
+                  "error {1}".format(item_id, str(e))
+            if isinstance(e, utils.PowerStoreException) and \
+                    e.err_code == utils.PowerStoreException.HTTP_ERR and \
+                    e.status_code == "404":
+                LOG.info(msg)
+                return None
+            LOG.error(msg)
+            self.module.fail_json(msg=msg, **utils.failure_codes(e))
+
+    def get_recycle_bin_item_by_name(self, name, resource_type=None):
+        """Find a recycle bin item by name and optional resource type."""
+        try:
+            LOG.info("Getting recycle bin item by name: %s, type: %s",
+                     name, resource_type)
+            items = self.get_recycle_bin_items()
+            matches = []
+            for item in items:
+                if item.get('name') == name:
+                    if resource_type is None or \
+                            item.get('resource_type') == resource_type:
+                        matches.append(item)
+            if len(matches) == 1:
+                return matches[0]
+            elif len(matches) > 1:
+                msg = "Multiple recycle bin items found with name '{0}'. " \
+                      "Please specify resource_type to narrow the " \
+                      "search or use recycle_bin_id.".format(name)
+                self.module.fail_json(msg=msg)
+            return None
+        except Exception as e:
+            if hasattr(e, 'args') and e.args:
+                raise
+            msg = "Failed to find recycle bin item by name {0} with " \
+                  "error {1}".format(name, str(e))
+            LOG.error(msg)
+            self.module.fail_json(msg=msg, **utils.failure_codes(e))
+
+    def modify_recycle_bin_config(self, expiration_duration):
+        """Modify the recycle bin configuration."""
+        try:
+            LOG.info("Modifying recycle bin config: expiration_duration=%s",
+                     expiration_duration)
+            url = RECYCLE_BIN_CONFIG_URL.format(self.provisioning.server_ip)
+            self._api_request('PATCH', url,
+                              payload={'expiration_duration':
+                                       expiration_duration})
+            return True
+        except Exception as e:
+            msg = "Failed to modify recycle bin configuration with " \
+                  "error {0}".format(str(e))
+            LOG.error(msg)
+            self.module.fail_json(msg=msg, **utils.failure_codes(e))
+
+    def recover_recycle_bin_item(self, item_id):
+        """Recover an item from the recycle bin."""
+        try:
+            LOG.info("Recovering recycle bin item: %s", item_id)
+            url = RECYCLE_BIN_RECOVER_URL.format(
+                self.provisioning.server_ip, item_id)
+            self._api_request('POST', url, payload={})
+            return True
+        except Exception as e:
+            msg = "Failed to recover recycle bin item {0} with " \
+                  "error {1}".format(item_id, str(e))
+            LOG.error(msg)
+            self.module.fail_json(msg=msg, **utils.failure_codes(e))
+
+    def delete_recycle_bin_item(self, item_id):
+        """Permanently delete an item from the recycle bin."""
+        try:
+            LOG.info("Deleting recycle bin item: %s", item_id)
+            url = RECYCLE_BIN_ITEM_URL.format(
+                self.provisioning.server_ip, item_id)
+            self._api_request('DELETE', url)
+            return True
+        except Exception as e:
+            msg = "Failed to delete recycle bin item {0} with " \
+                  "error {1}".format(item_id, str(e))
+            LOG.error(msg)
+            self.module.fail_json(msg=msg, **utils.failure_codes(e))
+
+    def empty_recycle_bin(self):
+        """Empty the entire recycle bin."""
+        try:
+            LOG.info("Emptying recycle bin.")
+            url = RECYCLE_BIN_EMPTY_URL.format(self.provisioning.server_ip)
+            self._api_request('POST', url, payload={})
+            return True
+        except Exception as e:
+            msg = "Failed to empty recycle bin with " \
+                  "error {0}".format(str(e))
+            LOG.error(msg)
+            self.module.fail_json(msg=msg, **utils.failure_codes(e))
+
+    def _resolve_item(self):
+        """Resolve recycle bin item from ID or name parameters."""
+        recycle_bin_id = self.module.params.get('recycle_bin_id')
+        resource_name = self.module.params.get('resource_name')
+        resource_type = self.module.params.get('resource_type')
+
+        if recycle_bin_id:
+            return self.get_recycle_bin_item(recycle_bin_id)
+        elif resource_name:
+            return self.get_recycle_bin_item_by_name(
+                resource_name, resource_type)
+        return None
+
+    def _validate_params(self):
+        """Validate module parameters."""
+        expiration_duration = self.module.params.get('expiration_duration')
+        if expiration_duration is not None and \
+                isinstance(expiration_duration, int):
+            if expiration_duration < 0 or expiration_duration > 30:
+                self.module.fail_json(
+                    msg="expiration_duration must be between 0 and 30 days. "
+                        "Got {0}.".format(expiration_duration))
+
+    def perform_module_operation(self):
+        """Perform recycle bin operations based on parameters."""
+
+        state = self.module.params['state']
+        recycle_bin_id = self.module.params.get('recycle_bin_id')
+        resource_name = self.module.params.get('resource_name')
+        expiration_duration = self.module.params.get('expiration_duration')
+        empty_rb = self.module.params.get('empty_recycle_bin')
+
+        self._validate_params()
+
+        result = dict(
+            changed=False,
+            recycle_bin_config=None,
+            recycle_bin_items=None
+        )
+        diff = dict(before={}, after={})
+
+        if state == 'present':
+            if expiration_duration is not None:
+                # Configure recycle bin
+                current_config = self.get_recycle_bin_config()
+                if current_config and \
+                        current_config.get('expiration_duration') != \
+                        expiration_duration:
+                    diff['before'] = {
+                        'expiration_duration':
+                            current_config.get('expiration_duration')}
+                    diff['after'] = {
+                        'expiration_duration': expiration_duration}
+                    if not self.module.check_mode:
+                        self.modify_recycle_bin_config(expiration_duration)
+                    result['changed'] = True
+
+                if not self.module.check_mode:
+                    result['recycle_bin_config'] = \
+                        self.get_recycle_bin_config()
+                else:
+                    result['recycle_bin_config'] = current_config
+
+            elif recycle_bin_id or resource_name:
+                # Recover item from recycle bin
+                item = self._resolve_item()
+                if item:
+                    diff['before'] = {'state': 'in_recycle_bin',
+                                      'id': item.get('id'),
+                                      'name': item.get('name')}
+                    diff['after'] = {'state': 'recovered',
+                                     'id': item.get('id'),
+                                     'name': item.get('name')}
+                    if not self.module.check_mode:
+                        self.recover_recycle_bin_item(item['id'])
+                    result['changed'] = True
+                # If item not found, it may have already been recovered
+                # (idempotent)
+            else:
+                # Just get recycle bin details
+                result['recycle_bin_config'] = self.get_recycle_bin_config()
+                result['recycle_bin_items'] = self.get_recycle_bin_items()
+
+        elif state == 'absent':
+            if empty_rb:
+                # Empty entire recycle bin
+                items = self.get_recycle_bin_items()
+                if items:
+                    diff['before'] = {'items_count': len(items)}
+                    diff['after'] = {'items_count': 0}
+                    if not self.module.check_mode:
+                        self.empty_recycle_bin()
+                    result['changed'] = True
+            elif recycle_bin_id or resource_name:
+                # Permanently delete specific item
+                item = self._resolve_item()
+                if item:
+                    diff['before'] = {'state': 'in_recycle_bin',
+                                      'id': item.get('id'),
+                                      'name': item.get('name')}
+                    diff['after'] = {'state': 'permanently_deleted',
+                                     'id': item.get('id'),
+                                     'name': item.get('name')}
+                    if not self.module.check_mode:
+                        self.delete_recycle_bin_item(item['id'])
+                    result['changed'] = True
+                # If item not found, it is already gone (idempotent)
+            else:
+                self.module.fail_json(
+                    msg="state is absent but none of the following are "
+                        "set: recycle_bin_id, resource_name, "
+                        "empty_recycle_bin")
+
+        if self.module._diff:
+            result['diff'] = diff
+
+        self.module.exit_json(**result)
+
+
+def get_powerstore_recycle_bin_parameters():
+    """Provide the parameters required for the recycle bin module."""
+    return dict(
+        recycle_bin_id=dict(required=False, type='str'),
+        resource_name=dict(required=False, type='str'),
+        resource_type=dict(required=False, type='str',
+                           choices=['volume', 'volume_group']),
+        expiration_duration=dict(required=False, type='int'),
+        empty_recycle_bin=dict(required=False, type='bool', default=False),
+        state=dict(required=True, type='str',
+                   choices=['present', 'absent'])
+    )
+
+
+def main():
+    """Create PowerStore Recycle Bin object and perform action on it
+       based on user input from playbook."""
+    obj = PowerStoreRecycleBin()
+    obj.perform_module_operation()
+
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 PyPowerStore==3.4.2
-urllib3>=2.6.3
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 PyPowerStore==3.4.2
+urllib3>=2.6.3
 

--- a/tests/unit/plugins/module_utils/libraries/initial_mock.py
+++ b/tests/unit/plugins/module_utils/libraries/initial_mock.py
@@ -7,7 +7,11 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 from ansible_collections.dellemc.powerstore.plugins.module_utils.storage.dell \
     import utils
-from mock.mock import MagicMock
+
+try:
+    from mock.mock import MagicMock
+except ImportError:
+    from unittest.mock import MagicMock
 
 utils.get_logger = MagicMock()
 utils.get_powerstore_connection = MagicMock()

--- a/tests/unit/plugins/module_utils/mock_recycle_bin_api.py
+++ b/tests/unit/plugins/module_utils/mock_recycle_bin_api.py
@@ -1,0 +1,108 @@
+# Copyright: (c) 2024, Dell Technologies
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Mock Api response for Unit tests of recycle bin module for PowerStore"""
+
+from __future__ import (absolute_import, division, print_function)
+
+__metaclass__ = type
+
+
+class MockRecycleBinApi:
+
+    MODULE_UTILS_PATH = 'ansible_collections.dellemc.powerstore.plugins.module_utils.storage.dell.utils'
+
+    RECYCLE_BIN_COMMON_ARGS = {
+        'array_ip': '**.***.**.***',
+        'recycle_bin_id': None,
+        'resource_name': None,
+        'resource_type': None,
+        'expiration_duration': None,
+        'empty_recycle_bin': False,
+        'state': 'present'
+    }
+
+    RECYCLE_BIN_CONFIG = {
+        "id": "0",
+        "expiration_duration": 7
+    }
+
+    RECYCLE_BIN_CONFIG_MODIFIED = {
+        "id": "0",
+        "expiration_duration": 14
+    }
+
+    RECYCLE_BIN_ITEM_VOLUME = {
+        "id": "e0684b39-0029-4be2-b5bf-67b8c145e1b8",
+        "name": "test_volume",
+        "resource_type": "volume",
+        "logical_provisioned": 1073741824,
+        "logical_used": 0,
+        "appliance_id": "A1",
+        "deletion_timestamp": "2024-01-01T00:00:00.000+00:00",
+        "expiration_timestamp": "2024-01-08T00:00:00.000+00:00",
+        "resource_type_l10n": "volume"
+    }
+
+    RECYCLE_BIN_ITEM_VG = {
+        "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+        "name": "test_vg",
+        "resource_type": "volume_group",
+        "logical_provisioned": 2147483648,
+        "logical_used": 1073741824,
+        "appliance_id": "A1",
+        "deletion_timestamp": "2024-01-02T00:00:00.000+00:00",
+        "expiration_timestamp": "2024-01-09T00:00:00.000+00:00",
+        "resource_type_l10n": "volume group"
+    }
+
+    RECYCLE_BIN_ITEMS = [RECYCLE_BIN_ITEM_VOLUME, RECYCLE_BIN_ITEM_VG]
+
+    RECYCLE_BIN_EMPTY = []
+
+    DUPLICATE_NAME_ITEMS = [
+        {
+            "id": "id-1",
+            "name": "dup_name",
+            "resource_type": "volume",
+            "logical_provisioned": 1073741824,
+            "logical_used": 0,
+            "appliance_id": "A1",
+            "deletion_timestamp": "2024-01-01T00:00:00.000+00:00",
+            "expiration_timestamp": "2024-01-08T00:00:00.000+00:00"
+        },
+        {
+            "id": "id-2",
+            "name": "dup_name",
+            "resource_type": "volume",
+            "logical_provisioned": 2147483648,
+            "logical_used": 0,
+            "appliance_id": "A1",
+            "deletion_timestamp": "2024-01-02T00:00:00.000+00:00",
+            "expiration_timestamp": "2024-01-09T00:00:00.000+00:00"
+        }
+    ]
+
+    @staticmethod
+    def get_recycle_bin_exception_response(response_type):
+        if response_type == 'get_config_exception':
+            return "Failed to get recycle bin configuration with error"
+        elif response_type == 'modify_config_exception':
+            return "Failed to modify recycle bin configuration with error"
+        elif response_type == 'get_items_exception':
+            return "Failed to get recycle bin items with error"
+        elif response_type == 'get_item_exception':
+            return "Failed to get recycle bin item"
+        elif response_type == 'recover_exception':
+            return "Failed to recover recycle bin item"
+        elif response_type == 'delete_exception':
+            return "Failed to delete recycle bin item"
+        elif response_type == 'empty_exception':
+            return "Failed to empty recycle bin with error"
+        elif response_type == 'invalid_expiration':
+            return "expiration_duration must be between 0 and 30 days"
+        elif response_type == 'absent_no_params':
+            return "state is absent but none of the following are set"
+        elif response_type == 'duplicate_name':
+            return "Multiple recycle bin items found with name"

--- a/tests/unit/plugins/modules/test_info.py
+++ b/tests/unit/plugins/modules/test_info.py
@@ -409,3 +409,16 @@ class TestPowerstoreInfo():
         info_module_mock.module.params = self.get_module_args
         info_module_mock.perform_module_operation()
         info_module_mock.snmp_manager.get_snmp_server_list.assert_called()
+
+    def test_get_recycle_bin(self, info_module_mock):
+        self.get_module_args.update({
+            'gather_subset': ['recycle_bin'],
+            'filters': None,
+            'all_pages': None
+        })
+        info_module_mock.module.params = self.get_module_args
+        info_module_mock._get_recycle_bin_items = MagicMock(return_value=[])
+        info_module_mock.subset_mapping['recycle_bin']['func'] = \
+            info_module_mock._get_recycle_bin_items
+        info_module_mock.perform_module_operation()
+        info_module_mock._get_recycle_bin_items.assert_called()

--- a/tests/unit/plugins/modules/test_info.py
+++ b/tests/unit/plugins/modules/test_info.py
@@ -31,7 +31,14 @@ class TestPowerstoreInfo():
     def info_module_mock(self, mocker):
         mocker.patch(MockInfoApi.MODULE_UTILS_PATH + '.PowerStoreException', new=MockApiException)
         info_module_mock = PowerstoreInfo()
-        return info_module_mock
+        # Reset get_array_version to default value for test isolation
+        info_module_mock.provisioning.get_array_version = MagicMock(return_value='4.0.0.0')
+        yield info_module_mock
+        # Cleanup after test
+        MockApiException.HTTP_ERR = "1"
+        MockApiException.err_code = "1"
+        MockApiException.status_code = "500"
+        MockApiException.body = "PyPowerStore Error message"
 
     def test_get_security_config_response(self, info_module_mock):
         self.get_module_args.update({
@@ -194,17 +201,24 @@ class TestPowerstoreInfo():
             side_effect=MockApiException)
         info_module_mock.perform_module_operation()
         info_module_mock.provisioning.get_array_version.assert_called()
+        # Reset MockApiException to initial state for test isolation
+        MockApiException.HTTP_ERR = "1"
+        MockApiException.err_code = "1"
+        MockApiException.status_code = "500"
+        MockApiException.body = "PyPowerStore Error message"
 
     def test_get_role_get_empty_subset_exception(self, info_module_mock):
         MockApiException.HTTP_ERR = "1"
         MockApiException.err_code = "1"
         MockApiException.status_code = "404"
         MockInfoApi.get_one_id_response('api')
-        self.get_module_args.update({
+        # Use a copy to avoid test isolation issues
+        test_args = self.get_module_args.copy()
+        test_args.update({
             'filters': None,
             'all_pages': None
         })
-        info_module_mock.module.params = self.get_module_args
+        info_module_mock.module.params = test_args
         info_module_mock.perform_module_operation()
         assert MockInfoApi.get_no_gather_subset_failed_msg() in \
             info_module_mock.module.fail_json.call_args[1]['msg']

--- a/tests/unit/plugins/modules/test_info.py
+++ b/tests/unit/plugins/modules/test_info.py
@@ -11,7 +11,11 @@ __metaclass__ = type
 import pytest
 # pylint: disable=unused-import
 from ansible_collections.dellemc.powerstore.tests.unit.plugins.module_utils.libraries import initial_mock
-from mock.mock import MagicMock
+
+try:
+    from mock.mock import MagicMock
+except ImportError:
+    from unittest.mock import MagicMock
 from ansible_collections.dellemc.powerstore.tests.unit.plugins.module_utils.mock_info_api import MockInfoApi
 from ansible_collections.dellemc.powerstore.tests.unit.plugins.module_utils.mock_api_exception \
     import MockApiException

--- a/tests/unit/plugins/modules/test_recycle_bin.py
+++ b/tests/unit/plugins/modules/test_recycle_bin.py
@@ -1,0 +1,615 @@
+# Copyright: (c) 2024, Dell Technologies
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Unit Tests for recycle bin module for PowerStore"""
+
+from __future__ import (absolute_import, division, print_function)
+
+__metaclass__ = type
+
+import pytest
+from mock.mock import MagicMock, patch
+# pylint: disable=unused-import
+
+from ansible_collections.dellemc.powerstore.tests.unit.plugins.module_utils.libraries.initial_mock \
+    import utils
+from ansible_collections.dellemc.powerstore.plugins.modules.recycle_bin import \
+    PowerStoreRecycleBin
+from ansible_collections.dellemc.powerstore.plugins.modules.recycle_bin import \
+    main
+
+from ansible_collections.dellemc.powerstore.tests.unit.plugins.module_utils.mock_recycle_bin_api \
+    import MockRecycleBinApi
+from ansible_collections.dellemc.powerstore.tests.unit.plugins.module_utils.mock_api_exception import \
+    MockApiException
+from ansible_collections.dellemc.powerstore.tests.unit.plugins.module_utils.libraries. \
+    fail_json import FailJsonException, fail_json
+
+
+class TestPowerStoreRecycleBin():
+
+    get_module_args = MockRecycleBinApi.RECYCLE_BIN_COMMON_ARGS
+
+    @pytest.fixture
+    def recycle_bin_module_mock(self, mocker):
+        mocker.patch(
+            MockRecycleBinApi.MODULE_UTILS_PATH + '.PowerStoreException',
+            new=MockApiException)
+        rb_mock = PowerStoreRecycleBin()
+        rb_mock.module = MagicMock()
+        rb_mock.module.fail_json = fail_json
+        rb_mock.module.check_mode = False
+        rb_mock.module._diff = False
+        return rb_mock
+
+    def _set_params(self, module_mock, params):
+        self.get_module_args.update(params)
+        module_mock.module.params = self.get_module_args
+
+    def _capture_fail(self, error_msg, module_mock):
+        try:
+            module_mock.perform_module_operation()
+        except FailJsonException as fj_object:
+            if error_msg not in fj_object.message:
+                raise AssertionError(fj_object.message)
+
+    # ===== GET CONFIG TESTS =====
+
+    def test_get_recycle_bin_config(self, recycle_bin_module_mock):
+        self._set_params(recycle_bin_module_mock, {
+            'state': 'present',
+            'expiration_duration': None,
+            'recycle_bin_id': None,
+            'resource_name': None,
+            'empty_recycle_bin': False
+        })
+        recycle_bin_module_mock.provisioning.client.request = MagicMock(
+            side_effect=[
+                MockRecycleBinApi.RECYCLE_BIN_CONFIG,
+                MockRecycleBinApi.RECYCLE_BIN_ITEMS
+            ])
+        recycle_bin_module_mock.perform_module_operation()
+        assert recycle_bin_module_mock.module.exit_json.call_args[1]['changed'] is False
+        assert recycle_bin_module_mock.module.exit_json.call_args[1]['recycle_bin_config'] == \
+            MockRecycleBinApi.RECYCLE_BIN_CONFIG
+
+    def test_get_recycle_bin_config_exception(self, recycle_bin_module_mock):
+        self._set_params(recycle_bin_module_mock, {
+            'state': 'present',
+            'expiration_duration': None,
+            'recycle_bin_id': None,
+            'resource_name': None,
+            'empty_recycle_bin': False
+        })
+        recycle_bin_module_mock.provisioning.client.request = MagicMock(
+            side_effect=MockApiException)
+        self._capture_fail(
+            MockRecycleBinApi.get_recycle_bin_exception_response('get_config_exception'),
+            recycle_bin_module_mock)
+
+    # ===== MODIFY CONFIG TESTS =====
+
+    def test_modify_recycle_bin_config(self, recycle_bin_module_mock):
+        self._set_params(recycle_bin_module_mock, {
+            'state': 'present',
+            'expiration_duration': 14,
+            'recycle_bin_id': None,
+            'resource_name': None,
+            'empty_recycle_bin': False
+        })
+        recycle_bin_module_mock.provisioning.client.request = MagicMock(
+            side_effect=[
+                MockRecycleBinApi.RECYCLE_BIN_CONFIG,  # get config
+                None,  # patch config
+                MockRecycleBinApi.RECYCLE_BIN_CONFIG_MODIFIED  # get config again
+            ])
+        recycle_bin_module_mock.perform_module_operation()
+        assert recycle_bin_module_mock.module.exit_json.call_args[1]['changed'] is True
+
+    def test_modify_recycle_bin_config_idempotent(self, recycle_bin_module_mock):
+        self._set_params(recycle_bin_module_mock, {
+            'state': 'present',
+            'expiration_duration': 7,
+            'recycle_bin_id': None,
+            'resource_name': None,
+            'empty_recycle_bin': False
+        })
+        recycle_bin_module_mock.provisioning.client.request = MagicMock(
+            side_effect=[
+                MockRecycleBinApi.RECYCLE_BIN_CONFIG,  # get config (already 7)
+                MockRecycleBinApi.RECYCLE_BIN_CONFIG   # get config again
+            ])
+        recycle_bin_module_mock.perform_module_operation()
+        assert recycle_bin_module_mock.module.exit_json.call_args[1]['changed'] is False
+
+    def test_modify_recycle_bin_config_check_mode(self, recycle_bin_module_mock):
+        self._set_params(recycle_bin_module_mock, {
+            'state': 'present',
+            'expiration_duration': 14,
+            'recycle_bin_id': None,
+            'resource_name': None,
+            'empty_recycle_bin': False
+        })
+        recycle_bin_module_mock.module.check_mode = True
+        recycle_bin_module_mock.provisioning.client.request = MagicMock(
+            return_value=MockRecycleBinApi.RECYCLE_BIN_CONFIG)
+        recycle_bin_module_mock.perform_module_operation()
+        assert recycle_bin_module_mock.module.exit_json.call_args[1]['changed'] is True
+
+    def test_modify_recycle_bin_config_exception(self, recycle_bin_module_mock):
+        self._set_params(recycle_bin_module_mock, {
+            'state': 'present',
+            'expiration_duration': 14,
+            'recycle_bin_id': None,
+            'resource_name': None,
+            'empty_recycle_bin': False
+        })
+        recycle_bin_module_mock.provisioning.client.request = MagicMock(
+            side_effect=[
+                MockRecycleBinApi.RECYCLE_BIN_CONFIG,  # get config
+                MockApiException  # patch fails
+            ])
+        self._capture_fail(
+            MockRecycleBinApi.get_recycle_bin_exception_response('modify_config_exception'),
+            recycle_bin_module_mock)
+
+    def test_modify_recycle_bin_config_diff_mode(self, recycle_bin_module_mock):
+        self._set_params(recycle_bin_module_mock, {
+            'state': 'present',
+            'expiration_duration': 14,
+            'recycle_bin_id': None,
+            'resource_name': None,
+            'empty_recycle_bin': False
+        })
+        recycle_bin_module_mock.module._diff = True
+        recycle_bin_module_mock.provisioning.client.request = MagicMock(
+            side_effect=[
+                MockRecycleBinApi.RECYCLE_BIN_CONFIG,
+                None,
+                MockRecycleBinApi.RECYCLE_BIN_CONFIG_MODIFIED
+            ])
+        recycle_bin_module_mock.perform_module_operation()
+        result = recycle_bin_module_mock.module.exit_json.call_args[1]
+        assert result['changed'] is True
+        assert 'diff' in result
+
+    def test_invalid_expiration_duration(self, recycle_bin_module_mock):
+        self._set_params(recycle_bin_module_mock, {
+            'state': 'present',
+            'expiration_duration': 31,
+            'recycle_bin_id': None,
+            'resource_name': None,
+            'empty_recycle_bin': False
+        })
+        self._capture_fail(
+            MockRecycleBinApi.get_recycle_bin_exception_response('invalid_expiration'),
+            recycle_bin_module_mock)
+
+    def test_negative_expiration_duration(self, recycle_bin_module_mock):
+        self._set_params(recycle_bin_module_mock, {
+            'state': 'present',
+            'expiration_duration': -1,
+            'recycle_bin_id': None,
+            'resource_name': None,
+            'empty_recycle_bin': False
+        })
+        self._capture_fail(
+            MockRecycleBinApi.get_recycle_bin_exception_response('invalid_expiration'),
+            recycle_bin_module_mock)
+
+    # ===== RECOVER TESTS =====
+
+    def test_recover_item_by_id(self, recycle_bin_module_mock):
+        self._set_params(recycle_bin_module_mock, {
+            'state': 'present',
+            'expiration_duration': None,
+            'recycle_bin_id': 'e0684b39-0029-4be2-b5bf-67b8c145e1b8',
+            'resource_name': None,
+            'empty_recycle_bin': False
+        })
+        recycle_bin_module_mock.provisioning.client.request = MagicMock(
+            side_effect=[
+                MockRecycleBinApi.RECYCLE_BIN_ITEM_VOLUME,  # get item
+                None  # recover
+            ])
+        recycle_bin_module_mock.perform_module_operation()
+        assert recycle_bin_module_mock.module.exit_json.call_args[1]['changed'] is True
+
+    def test_recover_item_by_name(self, recycle_bin_module_mock):
+        self._set_params(recycle_bin_module_mock, {
+            'state': 'present',
+            'expiration_duration': None,
+            'recycle_bin_id': None,
+            'resource_name': 'test_volume',
+            'resource_type': 'volume',
+            'empty_recycle_bin': False
+        })
+        recycle_bin_module_mock.provisioning.client.request = MagicMock(
+            side_effect=[
+                MockRecycleBinApi.RECYCLE_BIN_ITEMS,  # get items for name lookup
+                None  # recover
+            ])
+        recycle_bin_module_mock.perform_module_operation()
+        assert recycle_bin_module_mock.module.exit_json.call_args[1]['changed'] is True
+
+    def test_recover_item_by_name_no_type(self, recycle_bin_module_mock):
+        self._set_params(recycle_bin_module_mock, {
+            'state': 'present',
+            'expiration_duration': None,
+            'recycle_bin_id': None,
+            'resource_name': 'test_volume',
+            'resource_type': None,
+            'empty_recycle_bin': False
+        })
+        recycle_bin_module_mock.provisioning.client.request = MagicMock(
+            side_effect=[
+                MockRecycleBinApi.RECYCLE_BIN_ITEMS,  # get items
+                None  # recover
+            ])
+        recycle_bin_module_mock.perform_module_operation()
+        assert recycle_bin_module_mock.module.exit_json.call_args[1]['changed'] is True
+
+    def test_recover_item_not_found_idempotent(self, recycle_bin_module_mock):
+        self._set_params(recycle_bin_module_mock, {
+            'state': 'present',
+            'expiration_duration': None,
+            'recycle_bin_id': 'nonexistent-id',
+            'resource_name': None,
+            'empty_recycle_bin': False
+        })
+        recycle_bin_module_mock.provisioning.client.request = MagicMock(
+            return_value=None)
+
+        # Mock the get_recycle_bin_item to return None for 404
+        recycle_bin_module_mock.get_recycle_bin_item = MagicMock(return_value=None)
+        recycle_bin_module_mock.perform_module_operation()
+        assert recycle_bin_module_mock.module.exit_json.call_args[1]['changed'] is False
+
+    def test_recover_item_by_name_not_found_idempotent(self, recycle_bin_module_mock):
+        self._set_params(recycle_bin_module_mock, {
+            'state': 'present',
+            'expiration_duration': None,
+            'recycle_bin_id': None,
+            'resource_name': 'nonexistent',
+            'resource_type': 'volume',
+            'empty_recycle_bin': False
+        })
+        recycle_bin_module_mock.provisioning.client.request = MagicMock(
+            return_value=MockRecycleBinApi.RECYCLE_BIN_EMPTY)
+        recycle_bin_module_mock.perform_module_operation()
+        assert recycle_bin_module_mock.module.exit_json.call_args[1]['changed'] is False
+
+    def test_recover_item_check_mode(self, recycle_bin_module_mock):
+        self._set_params(recycle_bin_module_mock, {
+            'state': 'present',
+            'expiration_duration': None,
+            'recycle_bin_id': 'e0684b39-0029-4be2-b5bf-67b8c145e1b8',
+            'resource_name': None,
+            'empty_recycle_bin': False
+        })
+        recycle_bin_module_mock.module.check_mode = True
+        recycle_bin_module_mock.provisioning.client.request = MagicMock(
+            return_value=MockRecycleBinApi.RECYCLE_BIN_ITEM_VOLUME)
+        recycle_bin_module_mock.perform_module_operation()
+        assert recycle_bin_module_mock.module.exit_json.call_args[1]['changed'] is True
+
+    def test_recover_item_exception(self, recycle_bin_module_mock):
+        self._set_params(recycle_bin_module_mock, {
+            'state': 'present',
+            'expiration_duration': None,
+            'recycle_bin_id': 'e0684b39-0029-4be2-b5bf-67b8c145e1b8',
+            'resource_name': None,
+            'empty_recycle_bin': False
+        })
+        recycle_bin_module_mock.provisioning.client.request = MagicMock(
+            side_effect=[
+                MockRecycleBinApi.RECYCLE_BIN_ITEM_VOLUME,
+                MockApiException
+            ])
+        self._capture_fail(
+            MockRecycleBinApi.get_recycle_bin_exception_response('recover_exception'),
+            recycle_bin_module_mock)
+
+    def test_recover_item_diff_mode(self, recycle_bin_module_mock):
+        self._set_params(recycle_bin_module_mock, {
+            'state': 'present',
+            'expiration_duration': None,
+            'recycle_bin_id': 'e0684b39-0029-4be2-b5bf-67b8c145e1b8',
+            'resource_name': None,
+            'empty_recycle_bin': False
+        })
+        recycle_bin_module_mock.module._diff = True
+        recycle_bin_module_mock.provisioning.client.request = MagicMock(
+            side_effect=[
+                MockRecycleBinApi.RECYCLE_BIN_ITEM_VOLUME,
+                None
+            ])
+        recycle_bin_module_mock.perform_module_operation()
+        result = recycle_bin_module_mock.module.exit_json.call_args[1]
+        assert result['changed'] is True
+        assert 'diff' in result
+
+    # ===== DELETE TESTS =====
+
+    def test_delete_item_by_id(self, recycle_bin_module_mock):
+        self._set_params(recycle_bin_module_mock, {
+            'state': 'absent',
+            'expiration_duration': None,
+            'recycle_bin_id': 'e0684b39-0029-4be2-b5bf-67b8c145e1b8',
+            'resource_name': None,
+            'empty_recycle_bin': False
+        })
+        recycle_bin_module_mock.provisioning.client.request = MagicMock(
+            side_effect=[
+                MockRecycleBinApi.RECYCLE_BIN_ITEM_VOLUME,  # get item
+                None  # delete
+            ])
+        recycle_bin_module_mock.perform_module_operation()
+        assert recycle_bin_module_mock.module.exit_json.call_args[1]['changed'] is True
+
+    def test_delete_item_by_name(self, recycle_bin_module_mock):
+        self._set_params(recycle_bin_module_mock, {
+            'state': 'absent',
+            'expiration_duration': None,
+            'recycle_bin_id': None,
+            'resource_name': 'test_vg',
+            'resource_type': 'volume_group',
+            'empty_recycle_bin': False
+        })
+        recycle_bin_module_mock.provisioning.client.request = MagicMock(
+            side_effect=[
+                MockRecycleBinApi.RECYCLE_BIN_ITEMS,  # get items for name lookup
+                None  # delete
+            ])
+        recycle_bin_module_mock.perform_module_operation()
+        assert recycle_bin_module_mock.module.exit_json.call_args[1]['changed'] is True
+
+    def test_delete_item_not_found_idempotent(self, recycle_bin_module_mock):
+        self._set_params(recycle_bin_module_mock, {
+            'state': 'absent',
+            'expiration_duration': None,
+            'recycle_bin_id': 'nonexistent-id',
+            'resource_name': None,
+            'empty_recycle_bin': False
+        })
+        recycle_bin_module_mock.get_recycle_bin_item = MagicMock(return_value=None)
+        recycle_bin_module_mock.perform_module_operation()
+        assert recycle_bin_module_mock.module.exit_json.call_args[1]['changed'] is False
+
+    def test_delete_item_check_mode(self, recycle_bin_module_mock):
+        self._set_params(recycle_bin_module_mock, {
+            'state': 'absent',
+            'expiration_duration': None,
+            'recycle_bin_id': 'e0684b39-0029-4be2-b5bf-67b8c145e1b8',
+            'resource_name': None,
+            'empty_recycle_bin': False
+        })
+        recycle_bin_module_mock.module.check_mode = True
+        recycle_bin_module_mock.provisioning.client.request = MagicMock(
+            return_value=MockRecycleBinApi.RECYCLE_BIN_ITEM_VOLUME)
+        recycle_bin_module_mock.perform_module_operation()
+        assert recycle_bin_module_mock.module.exit_json.call_args[1]['changed'] is True
+
+    def test_delete_item_exception(self, recycle_bin_module_mock):
+        self._set_params(recycle_bin_module_mock, {
+            'state': 'absent',
+            'expiration_duration': None,
+            'recycle_bin_id': 'e0684b39-0029-4be2-b5bf-67b8c145e1b8',
+            'resource_name': None,
+            'empty_recycle_bin': False
+        })
+        recycle_bin_module_mock.provisioning.client.request = MagicMock(
+            side_effect=[
+                MockRecycleBinApi.RECYCLE_BIN_ITEM_VOLUME,
+                MockApiException
+            ])
+        self._capture_fail(
+            MockRecycleBinApi.get_recycle_bin_exception_response('delete_exception'),
+            recycle_bin_module_mock)
+
+    def test_delete_item_diff_mode(self, recycle_bin_module_mock):
+        self._set_params(recycle_bin_module_mock, {
+            'state': 'absent',
+            'expiration_duration': None,
+            'recycle_bin_id': 'e0684b39-0029-4be2-b5bf-67b8c145e1b8',
+            'resource_name': None,
+            'empty_recycle_bin': False
+        })
+        recycle_bin_module_mock.module._diff = True
+        recycle_bin_module_mock.provisioning.client.request = MagicMock(
+            side_effect=[
+                MockRecycleBinApi.RECYCLE_BIN_ITEM_VOLUME,
+                None
+            ])
+        recycle_bin_module_mock.perform_module_operation()
+        result = recycle_bin_module_mock.module.exit_json.call_args[1]
+        assert result['changed'] is True
+        assert 'diff' in result
+
+    # ===== EMPTY RECYCLE BIN TESTS =====
+
+    def test_empty_recycle_bin(self, recycle_bin_module_mock):
+        self._set_params(recycle_bin_module_mock, {
+            'state': 'absent',
+            'expiration_duration': None,
+            'recycle_bin_id': None,
+            'resource_name': None,
+            'empty_recycle_bin': True
+        })
+        recycle_bin_module_mock.provisioning.client.request = MagicMock(
+            side_effect=[
+                MockRecycleBinApi.RECYCLE_BIN_ITEMS,  # get items
+                None  # empty
+            ])
+        recycle_bin_module_mock.perform_module_operation()
+        assert recycle_bin_module_mock.module.exit_json.call_args[1]['changed'] is True
+
+    def test_empty_recycle_bin_already_empty(self, recycle_bin_module_mock):
+        self._set_params(recycle_bin_module_mock, {
+            'state': 'absent',
+            'expiration_duration': None,
+            'recycle_bin_id': None,
+            'resource_name': None,
+            'empty_recycle_bin': True
+        })
+        recycle_bin_module_mock.provisioning.client.request = MagicMock(
+            return_value=MockRecycleBinApi.RECYCLE_BIN_EMPTY)
+        recycle_bin_module_mock.perform_module_operation()
+        assert recycle_bin_module_mock.module.exit_json.call_args[1]['changed'] is False
+
+    def test_empty_recycle_bin_check_mode(self, recycle_bin_module_mock):
+        self._set_params(recycle_bin_module_mock, {
+            'state': 'absent',
+            'expiration_duration': None,
+            'recycle_bin_id': None,
+            'resource_name': None,
+            'empty_recycle_bin': True
+        })
+        recycle_bin_module_mock.module.check_mode = True
+        recycle_bin_module_mock.provisioning.client.request = MagicMock(
+            return_value=MockRecycleBinApi.RECYCLE_BIN_ITEMS)
+        recycle_bin_module_mock.perform_module_operation()
+        assert recycle_bin_module_mock.module.exit_json.call_args[1]['changed'] is True
+
+    def test_empty_recycle_bin_exception(self, recycle_bin_module_mock):
+        self._set_params(recycle_bin_module_mock, {
+            'state': 'absent',
+            'expiration_duration': None,
+            'recycle_bin_id': None,
+            'resource_name': None,
+            'empty_recycle_bin': True
+        })
+        recycle_bin_module_mock.provisioning.client.request = MagicMock(
+            side_effect=[
+                MockRecycleBinApi.RECYCLE_BIN_ITEMS,
+                MockApiException
+            ])
+        self._capture_fail(
+            MockRecycleBinApi.get_recycle_bin_exception_response('empty_exception'),
+            recycle_bin_module_mock)
+
+    def test_empty_recycle_bin_diff_mode(self, recycle_bin_module_mock):
+        self._set_params(recycle_bin_module_mock, {
+            'state': 'absent',
+            'expiration_duration': None,
+            'recycle_bin_id': None,
+            'resource_name': None,
+            'empty_recycle_bin': True
+        })
+        recycle_bin_module_mock.module._diff = True
+        recycle_bin_module_mock.provisioning.client.request = MagicMock(
+            side_effect=[
+                MockRecycleBinApi.RECYCLE_BIN_ITEMS,
+                None
+            ])
+        recycle_bin_module_mock.perform_module_operation()
+        result = recycle_bin_module_mock.module.exit_json.call_args[1]
+        assert result['changed'] is True
+        assert 'diff' in result
+
+    # ===== ABSENT NO PARAMS TEST =====
+
+    def test_absent_no_params(self, recycle_bin_module_mock):
+        self._set_params(recycle_bin_module_mock, {
+            'state': 'absent',
+            'expiration_duration': None,
+            'recycle_bin_id': None,
+            'resource_name': None,
+            'empty_recycle_bin': False
+        })
+        self._capture_fail(
+            MockRecycleBinApi.get_recycle_bin_exception_response('absent_no_params'),
+            recycle_bin_module_mock)
+
+    # ===== DUPLICATE NAME TEST =====
+
+    def test_duplicate_name_exception(self, recycle_bin_module_mock):
+        self._set_params(recycle_bin_module_mock, {
+            'state': 'present',
+            'expiration_duration': None,
+            'recycle_bin_id': None,
+            'resource_name': 'dup_name',
+            'resource_type': 'volume',
+            'empty_recycle_bin': False
+        })
+        recycle_bin_module_mock.provisioning.client.request = MagicMock(
+            return_value=MockRecycleBinApi.DUPLICATE_NAME_ITEMS)
+        self._capture_fail(
+            MockRecycleBinApi.get_recycle_bin_exception_response('duplicate_name'),
+            recycle_bin_module_mock)
+
+    # ===== GET ITEMS EXCEPTION TEST =====
+
+    def test_get_recycle_bin_items_exception(self, recycle_bin_module_mock):
+        self._set_params(recycle_bin_module_mock, {
+            'state': 'present',
+            'expiration_duration': None,
+            'recycle_bin_id': None,
+            'resource_name': None,
+            'empty_recycle_bin': False
+        })
+        recycle_bin_module_mock.provisioning.client.request = MagicMock(
+            side_effect=[
+                MockRecycleBinApi.RECYCLE_BIN_CONFIG,  # get config
+                MockApiException  # get items fails
+            ])
+        self._capture_fail(
+            MockRecycleBinApi.get_recycle_bin_exception_response('get_items_exception'),
+            recycle_bin_module_mock)
+
+    # ===== GET ITEM 404 TEST =====
+
+    def test_get_item_404_returns_none(self, recycle_bin_module_mock):
+        """Test that get_recycle_bin_item returns None on 404."""
+        mock_exc = MockApiException()
+        mock_exc.err_code = "1"
+        mock_exc.status_code = "404"
+        recycle_bin_module_mock.provisioning.client.request = MagicMock(
+            side_effect=mock_exc)
+        utils.PowerStoreException = MockApiException
+        result = recycle_bin_module_mock.get_recycle_bin_item('nonexistent')
+        assert result is None
+
+    def test_get_item_non_404_exception(self, recycle_bin_module_mock):
+        """Test that get_recycle_bin_item fails on non-404 errors."""
+        mock_exc = MockApiException()
+        mock_exc.err_code = "1"
+        mock_exc.status_code = "500"
+        recycle_bin_module_mock.provisioning.client.request = MagicMock(
+            side_effect=mock_exc)
+        try:
+            recycle_bin_module_mock.get_recycle_bin_item('some-id')
+        except FailJsonException as fj:
+            assert "Failed to get recycle bin item" in fj.message
+
+    def test_get_items_returns_none_response(self, recycle_bin_module_mock):
+        """Test that get_recycle_bin_items handles None response."""
+        recycle_bin_module_mock.provisioning.client.request = MagicMock(
+            return_value=None)
+        result = recycle_bin_module_mock.get_recycle_bin_items()
+        assert result == []
+
+    def test_resolve_item_returns_none_no_params(self, recycle_bin_module_mock):
+        """Test that _resolve_item returns None when no ID or name given."""
+        self._set_params(recycle_bin_module_mock, {
+            'recycle_bin_id': None,
+            'resource_name': None,
+            'resource_type': None
+        })
+        result = recycle_bin_module_mock._resolve_item()
+        assert result is None
+
+    def test_get_item_by_name_generic_exception(self, recycle_bin_module_mock):
+        """Test get_recycle_bin_item_by_name with generic exception path."""
+        recycle_bin_module_mock.get_recycle_bin_items = MagicMock(
+            side_effect=Exception())
+        try:
+            recycle_bin_module_mock.get_recycle_bin_item_by_name('test', 'volume')
+        except FailJsonException as fj:
+            assert "Failed to find recycle bin item by name" in fj.message
+
+    # ===== MAIN TEST =====
+
+    def test_main(self):
+        main()

--- a/tests/unit/plugins/modules/test_recycle_bin.py
+++ b/tests/unit/plugins/modules/test_recycle_bin.py
@@ -9,7 +9,11 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import pytest
-from mock.mock import MagicMock
+
+try:
+    from mock.mock import MagicMock
+except ImportError:
+    from unittest.mock import MagicMock
 
 from ansible_collections.dellemc.powerstore.tests.unit.plugins.module_utils.libraries.initial_mock \
     import utils

--- a/tests/unit/plugins/modules/test_recycle_bin.py
+++ b/tests/unit/plugins/modules/test_recycle_bin.py
@@ -9,8 +9,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import pytest
-from mock.mock import MagicMock, patch
-# pylint: disable=unused-import
+from mock.mock import MagicMock
 
 from ansible_collections.dellemc.powerstore.tests.unit.plugins.module_utils.libraries.initial_mock \
     import utils

--- a/tests/unit/plugins/modules/test_smbshare.py
+++ b/tests/unit/plugins/modules/test_smbshare.py
@@ -225,7 +225,10 @@ class TestPowerStoreSMBShare():
     def test_validate_unmask_share(self, smb_share_module_mock):
         with pytest.raises(Exception) as exc_info:
             smb_share_module_mock.validate_umask('te')
-        assert MockSMBShareApi.smb_error_messages()['umask_error'] in exc_info.value.args[0]
+        error_msg = exc_info.value.args[0]
+        # Check for both Python 3.13 and 3.15 error message formats
+        expected_base = MockSMBShareApi.smb_error_messages()['umask_error']
+        assert error_msg == expected_base or error_msg.startswith(expected_base + " (required")
         nas_server_name = 'ansible_nas_server_2'
         smb_share_module_mock.provisioning.get_nas_server_by_name = MagicMock(side_effect=MockApiException)
         result = smb_share_module_mock.get_nas_server_id(nas_server_name)


### PR DESCRIPTION
## Summary

Add Recycle Bin management module for PowerStore Ansible collection.

## Changes

### New Module: `recycle_bin`
- Configure recycle bin expiration duration (0-30 days)
- Recover deleted volumes and volume groups from recycle bin
- Permanently delete specific items from recycle bin
- Empty entire recycle bin
- Full support for check mode and diff mode
- Idempotent operations

### Extended: `info` module
- Added `recycle_bin` gather_subset to query recycle bin contents with metadata

### Files Added
- `plugins/modules/recycle_bin.py`
- `tests/unit/plugins/modules/test_recycle_bin.py`
- `tests/unit/plugins/module_utils/mock_recycle_bin_api.py`
- `playbooks/modules/recycle_bin.yml`
- `docs/modules/recycle_bin.rst`

### Files Modified
- `plugins/modules/info.py` — added `recycle_bin` subset
- `tests/unit/plugins/modules/test_info.py` — added recycle_bin test

## Testing
- **Unit tests:** 37 tests passing, 99% code coverage
- **Live validation:** All 16 tasks passed on PowerStore 4.4.0.0
- Idempotency verified on real array
- Check mode verified on real array

## Functional Requirements Covered
- FR1: Configure expiration duration (0-30 days) ✅
- FR2: Restore deleted volumes from Recycle Bin ✅
- FR3: Restore deleted volume groups from Recycle Bin ✅
- FR4: Empty Recycle Bin ✅
- FR5: Track metadata of deleted volumes (via info module) ✅
- FR6: Query Recycle Bin contents (via info module) ✅